### PR TITLE
Makefile improvements

### DIFF
--- a/projects/make/Makefile
+++ b/projects/make/Makefile
@@ -1,6 +1,6 @@
 INCLUDES=
-CFLAGS=$(INCLUDES) -O2
-CXXFLAGS=$(CFLAGS) -std=c++14
+CFLAGS:=$(INCLUDES) -O2 $(CFLAGS)
+CXXFLAGS:=$(INCLUDES) -O2 -std=c++14 $(CXXFLAGS)
 
 C_SRCS= \
 src/external/inih/ini.c

--- a/projects/make/Makefile
+++ b/projects/make/Makefile
@@ -1,6 +1,3 @@
-CC=gcc
-CXX=g++
-
 INCLUDES=
 CFLAGS=$(INCLUDES) -O2
 CXXFLAGS=$(CFLAGS) -std=c++14
@@ -31,7 +28,7 @@ clean:
 
 build/ClangBuildAnalyzer: $(C_OBJS) $(CPP_OBJS)
 	$(CXX) -o $@ $(C_OBJS) $(CPP_OBJS)
- 
+
 build/%.o: %.c
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -o $@ -c $<


### PR DESCRIPTION
1. I have removed hardcoded `gcc` and `g++` compilers from the Makefile so that system default compilers are used (`cc` and `g++` on my machine). This also allows user to specify compilers of their choice via `CC` and `CXX` variables like so:
```
$ CC=gcc-7 CXX=clang++ make -f projects/make/Makefile
```
2. Along the same lines, user will now be able to pass custom `CFLAGS` and `CXXFLAGS`:
```
$ CFLAGS='-Wall' CXXFLAGS='-Werror' make -f projects/make/Makefile
```
To ensure that C-specific flags (e.g. `-std=c99`) don't interfere with C++ compiler, `CXXFLAGS` no longer depend on `CFLAGS`.