### PR TITLE
Adding missing <iterator> header

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -5,6 +5,7 @@
 #include "external/sajson.h"
 #include <assert.h>
 #include <unordered_map>
+#include <iterator>
 
 static void DebugPrintEvents(const BuildEvents& events, const BuildNames& names)
 {


### PR DESCRIPTION
AddEvents uses std::back_inserter.  This was causing a build failure with MSVC 2015.