### PR TITLE
Support out of tree builds with make.

### DIFF
--- a/projects/make/Makefile
+++ b/projects/make/Makefile
@@ -37,3 +37,6 @@ build/%.o: %.cpp
 	mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) -o $@ -c $<
 
+srcdir = $(realpath $(dir $(lastword $(MAKEFILE_LIST)))/../..)
+vpath %.c $(srcdir)
+vpath %.cpp $(srcdir)


### PR DESCRIPTION
This lets you run the `Makefile` from any location and have the
build products be placed outside of the source tree.

Example:

    mkdir build/utils
    cd build/utils
    make -f ../../src/third-party/ClangBuildAnalyzer/projects/make/Makefile
    ./build/ClangBuildAnalyzer