### PR TITLE
Add a missing include of <stdio.h>

### DIFF
--- a/src/Allocator.cpp
+++ b/src/Allocator.cpp
@@ -9,6 +9,7 @@
 struct IUnknown; // workaround for old Win SDK header failures when using /permissive-
 #include <windows.h>
 #else
+#include <stdio.h>
 #include <sys/mman.h>
 #endif
 


### PR DESCRIPTION
Fixes the following error when building with Clang 9 and libc++ on Linux:

```
clang++  -O2 -std=c++14  -o build/src/Allocator.o -c src/Allocator.cpp
src/Allocator.cpp:45:13: error: use of undeclared identifier 'printf'
            printf("ERROR: failed to allocate %zu bytes via mmap\n", count);
            ^
1 error generated.
```