### PR TITLE
Make --start step optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,14 +15,15 @@ reports from multiple compilations, and output "what took the most time" summary
 
 ### Usage
 
-1. **Start the build capture**: `ClangBuildAnalyzer --start <artifacts_folder>`<br/>
+1. **Start the build capture (optional)**: `ClangBuildAnalyzer --start <artifacts_folder>`<br/>
    This will write current timestamp in a `ClangBuildAnalyzerSession.txt` file under the given `artifacts_folder`. The artifacts
    folder is where the compiled object files (and time trace report files) are expected to be produced by your build.
 1. **Do your build**. Does not matter how; an IDE build, a makefile, a shell script, whatever. As long as it invokes
    Clang and passes `-ftime-trace` flag to the compiler (**Clang 9.0 or later is required** for this).
 1. **Stop the build capture**: `ClangBuildAnalyzer --stop <artifacts_folder> <capture_file>`<br/>
-   This will find all Clang time trace compatible `*.json` files under the given `artifacts_folder` that were modified after
-   `--start` step was done (Clang `-ftime-trace` produces one JSON file next to each object file), and smashes them together into
+   This will find all Clang time trace compatible `*.json` files (Clang `-ftime-trace` produces one JSON file next to each object file)
+   under the given `artifacts_folder` that were modified during the session if
+   `--start` step was done or all of them if not, and smashes them together into
    one big `capture_file`.
 1. **Run the build analysis**: `ClangBuildAnalyzer --analyze <capture_file>`<br/>
    This will read the `capture_file` produced by `--stop` step, calculate the slowest things and print them. If a
@@ -45,7 +46,7 @@ Compilation (1761 times):
  18046 ms: artifacts/Editor_Src_4.o
  17026 ms: artifacts/Modules_Audio_Public_1.o
  16581 ms: artifacts/Runtime_Camera_4.o
- 
+
 **** Files that took longest to codegen (compiler backend):
 145761 ms: artifacts/Modules_TLS_0.o
 123048 ms: artifacts/Runtime_Core_Containers_1.o
@@ -56,7 +57,7 @@ Compilation (1761 times):
  19006 ms: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::... (2665 times, avg 7 ms)
  12821 ms: std::__1::map<core::basic_string<char, core::StringStorageDefault<ch... (250 times, avg 51 ms)
   9142 ms: std::__1::map<core::basic_string<char, core::StringStorageDefault<ch... (432 times, avg 21 ms)
-  8515 ms: std::__1::map<int, std::__1::pair<List<ListNode<Behaviour> > *, List... (392 times, avg 21 ms) 
+  8515 ms: std::__1::map<int, std::__1::pair<List<ListNode<Behaviour> > *, List... (392 times, avg 21 ms)
 
 **** Functions that took longest to compile:
   8710 ms: yyparse(glslang::TParseContext*) (External/ShaderCompilers/glslang/glslang/MachineIndependent/glslang_tab.cpp)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,23 +181,25 @@ static int RunStop(int argc, const char* argv[])
     std::string outFile = argv[3];
     printf("%sStopping build tracing and saving to '%s'...%s\n", col::kYellow, outFile.c_str(), col::kReset);
 
+    time_t startTime = 0;
+    time_t stopTime = time(NULL);
+
     std::string artifactsDir = argv[2];
     std::string fname = artifactsDir+"/ClangBuildAnalyzerSession.txt";
     FILE* fsession = fopen(fname.c_str(), "rt");
     if (!fsession)
     {
-        printf("%sERROR: failed to open session file at '%s'.%s\n", col::kRed, fname.c_str(), col::kReset);
-        return 1;
+        printf("%sWARN: failed to open session file at '%s'.%s\n", col::kYellow, fname.c_str(), col::kReset);
     }
-
-    time_t startTime = 0;
-    time_t stopTime = time(NULL);
+    else
+    {
 #if _MSC_VER
-    fscanf(fsession, "%llu", &startTime);
+        fscanf(fsession, "%llu", &startTime);
 #else
-    fscanf(fsession, "%lu", &startTime);
+        fscanf(fsession, "%lu", &startTime);
 #endif
-    fclose(fsession);
+        fclose(fsession);
+    }
 
     JsonFileFinder jsonFiles;
     jsonFiles.startTime = startTime;


### PR DESCRIPTION
More often than not, I need to analyze the whole artifacts directory. Making session start step optional means that I can achieve this goal easier and no extra files need to be created in the process.