### PR TITLE
Support parsing LLVM's new JSON streaming API

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -143,10 +143,17 @@ struct JsonFileFinder
             return;
         }
 
+        // convert windows new-lines to UNIX by removing
+        // all instances of '\r'
+        std::string markerCheckStr = str;
+        std::string::iterator it = std::remove(markerCheckStr.begin(), markerCheckStr.end(), '\r');
+        markerCheckStr.erase(it, markerCheckStr.end());
+
         // there might be non-clang time trace json files around;
         // the clang ones should have this inside them
         const char* clangMarker = "{\"cat\":\"\",\"pid\":1,\"tid\":0,\"ts\":0,\"ph\":\"M\",\"name\":\"process_name\",\"args\":{\"name\":\"clang\"}}";
-        if (strstr(str.c_str(), clangMarker) == NULL)
+        const char* newClangMarker = "{\n      \"args\": {\n        \"name\": \"clang\"\n      },\n      \"cat\": \"\",\n      \"name\": \"process_name\",\n      \"ph\": \"M\",\n      \"pid\": 1,\n      \"tid\": 0,\n      \"ts\": 0\n    }";
+        if (strstr(markerCheckStr.c_str(), clangMarker) == NULL && strstr(markerCheckStr.c_str(), newClangMarker) == NULL)
             return;
 
         // do not grab our own merged json file!


### PR DESCRIPTION
LLVM added a JSON steaming output API in
https://reviews.llvm.org/D60804 and updated the TimeProfiler to use it:
https://github.com/llvm-mirror/llvm/blob/master/lib/Support/TimeProfiler.cpp#L164

This adds "prettifies" the JSON with whitespace and causes the "clang" metadata element to output as:
`    {
      "args": {
        "name": "clang"
      },
      "cat": "",
      "name": "process_name",
      "ph": "M",
      "pid": 1,
      "tid": 0,
      "ts": 0
    }`

This fails the quick check when scanning for files. The output from the
JSON formatter appears to be deterministic; this change adds the new
output format.