### PR TITLE
Increase maximum file extension length

### DIFF
--- a/src/external/cute_files.h
+++ b/src/external/cute_files.h
@@ -73,7 +73,7 @@
 
 #define CUTE_FILES_MAX_PATH 1024
 #define CUTE_FILES_MAX_FILENAME 256
-#define CUTE_FILES_MAX_EXT 32
+#define CUTE_FILES_MAX_EXT 64
 
 struct cf_file_t;
 struct cf_dir_t;


### PR DESCRIPTION
Dotfiles with long file names in the artifacts directory caused me some problems. This isn't a robust fix, but it provides some breathing room.

(Since this is a bit of a hack, I wasn't sure whether it made sense to submit this upstream instead…)