### PR TITLE
Added LDFLAGS in Makefile

### DIFF
--- a/projects/make/Makefile
+++ b/projects/make/Makefile
@@ -27,7 +27,7 @@ clean:
 	rm -f build/ClangBuildAnalyzer $(C_OBJS) $(CPP_OBJS)
 
 build/ClangBuildAnalyzer: $(C_OBJS) $(CPP_OBJS)
-	$(CXX) -o $@ $(C_OBJS) $(CPP_OBJS)
+	$(CXX) -o $@ $(C_OBJS) $(CPP_OBJS) $(LDFLAGS)
 
 build/%.o: %.c
 	mkdir -p $(dir $@)


### PR DESCRIPTION
Sometimes we need to provide additional linker flags.

Thanks for such an excellent tool. It helps a lot.