### PR TITLE
Fix getcwd usage

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -33,7 +33,8 @@ void utils::Initialize()
     GetCurrentDirectoryW(1000, buffer);
     s_CurrentDir = WideToUtf(buffer);
     #else
-    s_CurrentDir = getcwd(NULL, 0);
+    char buffer[1000];
+    s_CurrentDir = getcwd(buffer, 1000);
     #endif
     ForwardSlashify(s_CurrentDir);
     if (!s_CurrentDir.empty())


### PR DESCRIPTION
It is better to use getcwd this way.
At least you won't have to free the memory manually.