### PR TITLE
Modernize CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,11 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(ClangBuildAnalyzer)
 
-string(APPEND CMAKE_CXX_FLAGS " -std=c++14 -O2")
-
-set(C_SRCS
+add_executable(ClangBuildAnalyzer)
+target_sources(ClangBuildAnalyzer PRIVATE
+# C sources
     "src/external/inih/ini.c"
-)
-
-set(CPP_SRCS
+# C++ sources	
     "src/Allocator.cpp"
     "src/Analysis.cpp"
     "src/BuildEvents.cpp"
@@ -20,5 +18,4 @@ set(CPP_SRCS
     "src/external/llvm-Demangle/lib/MicrosoftDemangle.cpp"
     "src/external/llvm-Demangle/lib/MicrosoftDemangleNodes.cpp"
 )
-
-add_executable(ClangBuildAnalyzer ${C_SRCS} ${CPP_SRCS})
+target_compile_features(ClangBuildAnalyzer PRIVATE cxx_std_14)


### PR DESCRIPTION
This version of CMakeLists.txt follows the "modern cmake" way by setting properties directly on the target.

I also removed the `-O2` from the flags as one should use the `Release` or `RelWithDebInfo` configurations to have optimized builds. This will also make it work across various compilers.

It will also use the correct flags for c++14 using any compiler.