### PR TITLE
Fixed writing of huge blobs to BufferedWriter

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -459,6 +459,12 @@ struct BufferedWriter
     {
         if (sz >= kBufferSize)
         {
+            if( size > 0 )
+            {
+                Flush();
+            }
+
+            XXH64_update(hasher, ptr, sz);
             fwrite(ptr, sz, 1, file);
             return;
         }


### PR DESCRIPTION
Tested on generating analysis report of project that contains huge cpp files