### PR TITLE
Fix atomic<int> deleted function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,7 +196,7 @@ static int RunStop(int argc, const char* argv[])
 
     // parse the json files into our data structures (in parallel)
     BuildEventsParser* parser = CreateBuildEventsParser();
-    std::atomic<int> fileCount = 0;
+    std::atomic<int> fileCount(0);
     {
         enki::TaskScheduler ts;
         ts.Initialize(std::min(std::thread::hardware_concurrency(), (uint32_t)jsonFiles.files.size()));


### PR DESCRIPTION
```
"std::atomic<int>::atomic(const std::atomic<int> &)" (declared at line 668 of "/usr/include/c++/7/atomic"),
required for copy that was eliminated, cannot be referenced -- it is a deleted functionC/C++(1815)
```