### PR TITLE
Fix compiler warning on format string

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -52,7 +52,7 @@ static void DebugPrintEvents(const BuildEvents& events, const BuildNames& names)
     for (size_t i = 0; i < events.size(); ++i)
     {
         const BuildEvent& event = events[EventIndex(int(i))];
-        printf("%4zi: t=%i t1=%7lld t2=%7lld par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), std::string(names[event.detailIndex].substr(0,130)).c_str());
+        printf("%4zi: t=%i t1=%7" PRId64 " t2=%7" PRId64 " par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), std::string(names[event.detailIndex].substr(0,130)).c_str());
     }
 }
 

--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -52,7 +52,7 @@ static void DebugPrintEvents(const BuildEvents& events, const BuildNames& names)
     for (size_t i = 0; i < events.size(); ++i)
     {
         const BuildEvent& event = events[EventIndex(int(i))];
-        printf("%4zi: t=%i t1=%7ld t2=%7ld par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), std::string(names[event.detailIndex].substr(0,130)).c_str());
+        printf("%4zi: t=%i t1=%7lld t2=%7lld par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), std::string(names[event.detailIndex].substr(0,130)).c_str());
     }
 }
 


### PR DESCRIPTION
I was getting compiler warnings on format string type mismatch:
```
[  6%] Building CXX object CMakeFiles/ClangBuildAnalyzer.dir/src/BuildEvents.cpp.o
/Users/brett/git/ClangBuildAnalyzer/src/BuildEvents.cpp:55:92: warning: format
      specifies type 'long' but the argument has type 'int64_t'
      (aka 'long long') [-Wformat]
  ...t1=%7ld t2=%7ld par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts...
        ~~~~                                                         ^~~~~~~~
        %7lld
/Users/brett/git/ClangBuildAnalyzer/src/BuildEvents.cpp:55:102: warning: format
      specifies type 'long' but the argument has type 'long long' [-Wformat]
  ...%7ld par=%4i ch=%4zi det=%s\n", i, (int) event.type, event.ts, event.ts+event.dur...
     ~~~~                                                           ^~~~~~~~~~~~~~~~~~
     %7lld
2 warnings generated.
```