### PR TITLE
Add install step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(ClangBuildAnalyzer)
 
+include(GNUInstallDirs)
+
 set(SRC
 # C sources
     "src/external/inih/ini.c"
@@ -23,3 +25,7 @@ set(SRC
 add_executable(ClangBuildAnalyzer "${SRC}")
 target_compile_features(ClangBuildAnalyzer PRIVATE cxx_std_17)
 target_link_libraries(ClangBuildAnalyzer -lrt -lpthread)
+
+install(TARGETS ClangBuildAnalyzer
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        )


### PR DESCRIPTION
This change adds new cmake target `install`, which installs binary into OS.
Default location is `${CMAKE_INSTALL_PREFIX}/bin/ClangBuildAnalyzer` and `CMAKE_INSTALL_PREFIX` is usually `/usr/local/`.