### PR TITLE
Fix a memory leak in BufferedWriter

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -448,6 +448,7 @@ struct BufferedWriter
         XXH64_hash_t hash = XXH64_digest(hasher);
         fwrite(&hash, sizeof(hash), 1, file);
         fclose(file);
+        XXH64_freeState(hasher);
     }
     
     template<typename T> void Write(const T& t)


### PR DESCRIPTION
Fix a memory leak in `BufferedWriter`:

```
==2983106==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0xa6f3af in malloc
    #1 0x9b9134 in XXH_malloc .../xxHash/xxhash.h:755
    #2 0x9bc08d in XXH64_createState .../xxHash/xxhash.h:1689
    #3 0x44bb71 in BufferedWriter::BufferedWriter(_IO_FILE*) .../BuildEvents.cpp:443
    ...
````
which is caused by missing `XXH64_freeState`.