### PR TITLE
Fix a UB in BufferedWriter::Write

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -456,6 +456,7 @@ struct BufferedWriter
     }
     void Write(const void* ptr, size_t sz)
     {
+        if (sz == 0) return;
         if (sz >= kBufferSize)
         {
             if( size > 0 )


### PR DESCRIPTION
Fix a UB in `BufferedWriter::Write`:
```
    #0 0x44c318 in BufferedWriter::Write(void const*, unsigned long) .../BuildEvents.cpp:473
    #1 0x44b615 in SaveBuildEvents(BuildEventsParser*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) .../BuildEvents.cpp:556
    #2 0x59b0ca in ProcessJsonFiles(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, long, long) .../main.cpp:194
    ...
```
which is caused by passing a null pointer to `memcpy`.
 