### PR TITLE
Fix build on MinGW (MSYS2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,4 +22,9 @@ set(SRC
 )
 add_executable(ClangBuildAnalyzer "${SRC}")
 target_compile_features(ClangBuildAnalyzer PRIVATE cxx_std_17)
-target_link_libraries(ClangBuildAnalyzer -lrt -lpthread)
+
+if (MINGW)
+    target_link_libraries(ClangBuildAnalyzer -lpthread)
+else()
+    target_link_libraries(ClangBuildAnalyzer -lrt -lpthread)
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,7 +97,7 @@ static int RunStart(int argc, const char* argv[])
     return 0;
 }
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 static time_t FiletimeToTime(const FILETIME& ft)
 {
     ULARGE_INTEGER ull;
@@ -129,7 +129,7 @@ struct JsonFileFinder
         if (!cf_get_file_time(f->path, &mtime))
             return;
         time_t fileModTime;
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
         fileModTime = FiletimeToTime(mtime.time);
 #else
         fileModTime = mtime.time;


### PR DESCRIPTION
`mtime.time` is of type `FILETIME` when compiling under MinGW x64 using MSYS2. The presence of `-lrt` causes a linker error as well, removing it fixes the issue.