### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/BuildEvents.h
+++ b/src/BuildEvents.h
@@ -11,7 +11,7 @@
 
 #ifdef _MSC_VER
 #define ftello64 _ftelli64
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #define ftello64 ftello
 #endif
 

--- a/src/external/enkiTS/LockLessMultiReadPipe.h
+++ b/src/external/enkiTS/LockLessMultiReadPipe.h
@@ -19,11 +19,13 @@
 #pragma once
 
 #include <stdint.h>
-#include <assert.h>
-
 #include <atomic>
 #include <string.h>
 
+#ifndef ENKI_ASSERT
+#include <assert.h>
+#define ENKI_ASSERT(x) assert(x)
+#endif
 
 namespace enki
 {
@@ -90,7 +92,7 @@ namespace enki
         , m_ReadCount(0)
         , m_ReadIndex(0)
     {
-        assert( cSizeLog2 < 32 );
+        ENKI_ASSERT( cSizeLog2 < 32 );
         memset( (void*)m_Flags, 0, sizeof( m_Flags ) );
     }
 
@@ -241,7 +243,7 @@ namespace enki
         // Add - safe to perform from any thread
         void WriterWriteFront( T* pNode_ )
         {
-            assert( pNode_ );
+            ENKI_ASSERT( pNode_ );
             pNode_->pNext = NULL;
             T* pPrev = pHead.exchange( pNode_ );
             pPrev->pNext = pNode_;

--- a/src/external/enkiTS/TaskScheduler.cpp
+++ b/src/external/enkiTS/TaskScheduler.cpp
@@ -1,13 +1,13 @@
 // Copyright (c) 2013 Doug Binks
-// 
+//
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
 // arising from the use of this software.
-// 
+//
 // Permission is granted to anyone to use this software for any purpose,
 // including commercial applications, and to alter it and redistribute it
 // freely, subject to the following restrictions:
-// 
+//
 // 1. The origin of this software must not be misrepresented; you must not
 //    claim that you wrote the original software. If you use this software
 //    in a product, an acknowledgement in the product documentation would be
@@ -15,8 +15,6 @@
 // 2. Altered source versions must be plainly marked as such, and must not be
 //    misrepresented as being the original software.
 // 3. This notice may not be removed or altered from any source distribution.
-
-#include <assert.h>
 
 #include "TaskScheduler.h"
 #include "LockLessMultiReadPipe.h"
@@ -42,30 +40,65 @@ namespace
 #define ENKI_FILE_AND_LINE  gc_File, gc_Line
 #endif
 
+// UWP and MinGW don't have GetActiveProcessorCount
+#if defined(_WIN64) \
+    && !defined(__MINGW32__) \
+    && !(defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_PC_APP || WINAPI_FAMILY == WINAPI_FAMILY_PHONE_APP))
+#define ENKI_USE_WINDOWS_PROCESSOR_API
+#endif
+
+#ifdef ENKI_USE_WINDOWS_PROCESSOR_API
+#ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+#endif
+
+#ifndef NOMINMAX
+    #define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
+uint32_t enki::GetNumHardwareThreads()
+{
+#ifdef ENKI_USE_WINDOWS_PROCESSOR_API
+    return GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+#else
+    return std::thread::hardware_concurrency();
+#endif
+}
+
 namespace enki
 {
-    static const uint32_t gc_PipeSizeLog2            = 8;
-    static const uint32_t gc_SpinCount               = 10;
-    static const uint32_t gc_SpinBackOffMulitplier   = 100;
-    static const uint32_t gc_MaxNumInitialPartitions = 8;
-    static const uint32_t gc_CacheLineSize           = 64; // awaiting std::hardware_constructive_interference_size
-};
+    static constexpr int32_t  gc_TaskStartCount          = 2;
+    static constexpr int32_t  gc_TaskAlmostCompleteCount = 1; // GetIsComplete() will return false, but execution is done and about to complete
+    static constexpr uint32_t gc_PipeSizeLog2            = 8;
+    static constexpr uint32_t gc_SpinCount               = 10;
+    static constexpr uint32_t gc_SpinBackOffMultiplier   = 100;
+    static constexpr uint32_t gc_MaxNumInitialPartitions = 8;
+    static constexpr uint32_t gc_MaxStolenPartitions     = 1 << gc_PipeSizeLog2;
+    static constexpr uint32_t gc_CacheLineSize           = 64;
+    // awaiting std::hardware_constructive_interference_size
+}
 
-// thread_local not well supported yet by C++11 compilers.
-#ifdef _MSC_VER
-    #if _MSC_VER <= 1800
-        #define thread_local __declspec(thread)
-    #endif
-#elif __APPLE__
-        // Apple thread_local currently not implemented despite it being in Clang.
-        #define thread_local __thread
+// thread_local not well supported yet by some older C++11 compilers.
+// For XCode before version 8 thread_local is not defined, so add to your compile defines: ENKI_THREAD_LOCAL __thread
+#ifndef ENKI_THREAD_LOCAL
+#if defined(_MSC_VER) && _MSC_VER <= 1800
+        #define ENKI_THREAD_LOCAL __declspec(thread)
+// Removed below as XCode supports thread_local since version 8
+// #elif __APPLE__
+//         // Apple thread_local currently not implemented in XCode before version 8 despite it being in Clang.
+//         #define ENKI_THREAD_LOCAL __thread
+#else
+        #define ENKI_THREAD_LOCAL thread_local
+#endif
 #endif
 
 
-// each software thread gets it's own copy of gtl_threadNum, so this is safe to use as a static variable
-static thread_local uint32_t                             gtl_threadNum       = 0;
+// each software thread gets its own copy of gtl_threadNum, so this is safe to use as a static variable
+static ENKI_THREAD_LOCAL uint32_t  gtl_threadNum             = enki::NO_THREAD_NUM;
 
-namespace enki 
+namespace enki
 {
     struct SubTaskSet
     {
@@ -74,18 +107,20 @@ namespace enki
     };
 
     // we derive class TaskPipe rather than typedef to get forward declaration working easily
-    class TaskPipe : public LockLessMultiReadPipe<gc_PipeSizeLog2,enki::SubTaskSet> {};
+    class TaskPipe : public LockLessMultiReadPipe<gc_PipeSizeLog2, enki::SubTaskSet> {};
 
     enum ThreadState : int32_t
     {
-        THREAD_STATE_NONE,                  // shouldn't get this value
-        THREAD_STATE_NOT_LAUNCHED,          // for debug purposes - indicates enki task thread not yet launched
-        THREAD_STATE_RUNNING,
-        THREAD_STATE_WAIT_TASK_COMPLETION,
-        THREAD_STATE_EXTERNAL_REGISTERED,
-        THREAD_STATE_EXTERNAL_UNREGISTERED,
-        THREAD_STATE_WAIT_NEW_TASKS,
-        THREAD_STATE_STOPPED,
+        ENKI_THREAD_STATE_NONE,                  // shouldn't get this value
+        ENKI_THREAD_STATE_NOT_LAUNCHED,          // for debug purposes - indicates enki task thread not yet launched
+        ENKI_THREAD_STATE_RUNNING,
+        ENKI_THREAD_STATE_PRIMARY_REGISTERED,    // primary thread is the one enkiTS was initialized on
+        ENKI_THREAD_STATE_EXTERNAL_REGISTERED,
+        ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED,
+        ENKI_THREAD_STATE_WAIT_TASK_COMPLETION,
+        ENKI_THREAD_STATE_WAIT_NEW_TASKS,
+        ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS,
+        ENKI_THREAD_STATE_STOPPED,
     };
 
     struct ThreadArgs
@@ -94,12 +129,15 @@ namespace enki
         TaskScheduler*           pTaskScheduler;
     };
 
-    struct alignas(enki::gc_CacheLineSize) ThreadDataStore 
+    struct alignas(enki::gc_CacheLineSize) ThreadDataStore
     {
-        std::atomic<ThreadState> threadState = { THREAD_STATE_NONE };
-        char prevent_false_Share[ enki::gc_CacheLineSize - sizeof(std::atomic<ThreadState>) ];
+        semaphoreid_t*           pWaitNewPinnedTaskSemaphore = nullptr;
+        std::atomic<ThreadState> threadState = { ENKI_THREAD_STATE_NONE };
+        uint32_t                 rndSeed = 0;
+        char prevent_false_Share[ enki::gc_CacheLineSize - sizeof(std::atomic<ThreadState>) - sizeof(semaphoreid_t*) - sizeof( uint32_t ) ]; // required to prevent alignment padding warning
     };
-    static_assert( sizeof( ThreadDataStore ) >= enki::gc_CacheLineSize, "ThreadDataStore may exhibit false sharing" );
+    constexpr size_t SIZEOFTHREADDATASTORE = sizeof( ThreadDataStore ); // for easier inspection
+    static_assert( SIZEOFTHREADDATASTORE == enki::gc_CacheLineSize, "ThreadDataStore may exhibit false sharing" );
 
     class PinnedTaskList : public LocklessMultiWriteIntrusiveList<IPinnedTask> {};
 
@@ -115,11 +153,7 @@ namespace
     {
         SubTaskSet splitTask = subTask_;
         uint32_t rangeLeft = subTask_.partition.end - subTask_.partition.start;
-
-        if( rangeToSplit_ > rangeLeft )
-        {
-            rangeToSplit_ = rangeLeft;
-        }
+        rangeToSplit_ = std::min( rangeToSplit_, rangeLeft );
         splitTask.partition.end = subTask_.partition.start + rangeToSplit_;
         subTask_.partition.start = splitTask.partition.end;
         return splitTask;
@@ -127,47 +161,56 @@ namespace
 
     #if ( defined _WIN32 && ( defined _M_IX86  || defined _M_X64 ) ) || ( defined __i386__ || defined __x86_64__ )
     // Note: see https://software.intel.com/en-us/articles/a-common-construct-to-avoid-the-contention-of-threads-architecture-agnostic-spin-wait-loops
-    static void SpinWait( uint32_t spinCount_ )
+    void SpinWait( uint32_t spinCount_ )
     {
         uint64_t end = __rdtsc() + spinCount_;
         while( __rdtsc() < end )
         {
             _mm_pause();
-        }        
+        }
     }
     #else
-    static void SpinWait( uint32_t spinCount_ )
+    void SpinWait( uint32_t spinCount_ )
     {
         while( spinCount_ )
         {
             // TODO: may have NOP or yield equiv
             --spinCount_;
-        }        
+        }
     }
     #endif
-}
 
-static void SafeCallback( ProfilerCallbackFunc func_, uint32_t threadnum_ )
-{
-    if( func_ != nullptr )
+    void SafeCallback( ProfilerCallbackFunc func_, uint32_t threadnum_ )
     {
-        func_( threadnum_ );
+        if( func_ != nullptr )
+        {
+            func_( threadnum_ );
+        }
     }
 }
 
-   
+
 ENKITS_API void* enki::DefaultAllocFunc( size_t align_, size_t size_, void* userData_, const char* file_, int line_ )
-{ 
+{
     (void)userData_; (void)file_; (void)line_;
     void* pRet;
 #ifdef _WIN32
     pRet = (void*)_aligned_malloc( size_, align_ );
 #else
-    int retval = posix_memalign( &pRet, align_, size_ );
-    (void)retval;	//unused
+    pRet = nullptr;
+    if( align_ <= size_ && align_ <= alignof(int64_t) )
+    {
+        // no need for alignment, use malloc
+        pRet = malloc( size_ );
+    }
+    else
+    {
+        int retval = posix_memalign( &pRet, align_, size_ );
+        (void)retval; // unused
+    }
 #endif
     return pRet;
-};
+}
 
 ENKITS_API void  enki::DefaultFreeFunc(  void* ptr_,   size_t size_, void* userData_, const char* file_, int line_ )
 {
@@ -177,19 +220,18 @@ ENKITS_API void  enki::DefaultFreeFunc(  void* ptr_,   size_t size_, void* userD
 #else
     free( ptr_ );
 #endif
-};
+}
 
 bool TaskScheduler::RegisterExternalTaskThread()
 {
     bool bRegistered = false;
     while( !bRegistered && m_NumExternalTaskThreadsRegistered < (int32_t)m_Config.numExternalTaskThreads  )
     {
-        for(uint32_t thread = 1; thread <= m_Config.numExternalTaskThreads; ++thread )
+        for(uint32_t thread = GetNumFirstExternalTaskThread(); thread < GetNumFirstExternalTaskThread() + m_Config.numExternalTaskThreads; ++thread )
         {
-            // ignore our thread
-            ThreadState threadStateExpected = THREAD_STATE_EXTERNAL_UNREGISTERED;
+            ThreadState threadStateExpected = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
             if( m_pThreadDataStore[thread].threadState.compare_exchange_strong(
-                threadStateExpected, THREAD_STATE_EXTERNAL_REGISTERED ) )
+                threadStateExpected, ENKI_THREAD_STATE_EXTERNAL_REGISTERED ) )
             {
                 ++m_NumExternalTaskThreadsRegistered;
                 gtl_threadNum = thread;
@@ -201,16 +243,33 @@ bool TaskScheduler::RegisterExternalTaskThread()
     return bRegistered;
 }
 
+bool TaskScheduler::RegisterExternalTaskThread( uint32_t threadNumToRegister_ )
+{
+    ENKI_ASSERT( threadNumToRegister_ >= GetNumFirstExternalTaskThread() );
+    ENKI_ASSERT( threadNumToRegister_ < ( GetNumFirstExternalTaskThread() + m_Config.numExternalTaskThreads ) );
+    ThreadState threadStateExpected = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
+    if( m_pThreadDataStore[threadNumToRegister_].threadState.compare_exchange_strong(
+        threadStateExpected, ENKI_THREAD_STATE_EXTERNAL_REGISTERED ) )
+    {
+        ++m_NumExternalTaskThreadsRegistered;
+        gtl_threadNum = threadNumToRegister_;
+        return true;
+    }
+    return false;
+}
+
+
 void TaskScheduler::DeRegisterExternalTaskThread()
 {
-    assert( gtl_threadNum );
+    ENKI_ASSERT( gtl_threadNum != enki::NO_THREAD_NUM );
+    ENKI_ASSERT( gtl_threadNum >= GetNumFirstExternalTaskThread() );
     ThreadState threadState = m_pThreadDataStore[gtl_threadNum].threadState.load( std::memory_order_acquire );
-    assert( threadState == THREAD_STATE_EXTERNAL_REGISTERED );
-    if( threadState == THREAD_STATE_EXTERNAL_REGISTERED )
+    ENKI_ASSERT( threadState == ENKI_THREAD_STATE_EXTERNAL_REGISTERED );
+    if( threadState == ENKI_THREAD_STATE_EXTERNAL_REGISTERED )
     {
         --m_NumExternalTaskThreadsRegistered;
-        m_pThreadDataStore[gtl_threadNum].threadState.store( THREAD_STATE_EXTERNAL_UNREGISTERED, std::memory_order_release );
-        gtl_threadNum = 0;
+        m_pThreadDataStore[gtl_threadNum].threadState.store( ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED, std::memory_order_release );
+        gtl_threadNum = enki::NO_THREAD_NUM;
     }
 }
 
@@ -219,19 +278,18 @@ uint32_t TaskScheduler::GetNumRegisteredExternalTaskThreads()
     return m_NumExternalTaskThreadsRegistered;
 }
 
-
 void TaskScheduler::TaskingThreadFunction( const ThreadArgs& args_ )
 {
     uint32_t threadNum  = args_.threadNum;
     TaskScheduler*  pTS = args_.pTaskScheduler;
     gtl_threadNum       = threadNum;
 
-    pTS->m_pThreadDataStore[threadNum].threadState.store( THREAD_STATE_RUNNING, std::memory_order_release );
+    pTS->m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_release );
     SafeCallback( pTS->m_Config.profilerCallbacks.threadStart, threadNum );
 
     uint32_t spinCount = 0;
-    uint32_t hintPipeToCheck_io = threadNum + 1;    // does not need to be clamped.
-    while( pTS->m_bRunning.load( std::memory_order_relaxed ) )
+    uint32_t hintPipeToCheck_io = threadNum + 1; // does not need to be clamped.
+    while( pTS->GetIsRunning() )
     {
         if( !pTS->TryRunTask( threadNum, hintPipeToCheck_io ) )
         {
@@ -243,7 +301,7 @@ void TaskScheduler::TaskingThreadFunction( const ThreadArgs& args_ )
             }
             else
             {
-                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMultiplier;
                 SpinWait( spinBackoffCount );
             }
         }
@@ -254,10 +312,8 @@ void TaskScheduler::TaskingThreadFunction( const ThreadArgs& args_ )
     }
 
     pTS->m_NumInternalTaskThreadsRunning.fetch_sub( 1, std::memory_order_release );
-    pTS->m_pThreadDataStore[threadNum].threadState.store( THREAD_STATE_STOPPED, std::memory_order_release );
+    pTS->m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_STOPPED, std::memory_order_release );
     SafeCallback( pTS->m_Config.profilerCallbacks.threadStop, threadNum );
-    return;
-
 }
 
 
@@ -282,25 +338,40 @@ void TaskScheduler::StartThreads()
     // we create one less thread than m_NumThreads as the main thread counts as one
     m_pThreadDataStore   = NewArray<ThreadDataStore>( m_NumThreads, ENKI_FILE_AND_LINE );
     m_pThreads           = NewArray<std::thread>( m_NumThreads, ENKI_FILE_AND_LINE );
-    m_bRunning = 1;
+    m_bRunning = true;
+    m_bWaitforAllCalled = false;
+    m_bShutdownRequested = false;
 
-    for( uint32_t thread = 0; thread < m_Config.numExternalTaskThreads + 1; ++thread )
+    // current thread is primary enkiTS thread
+    m_pThreadDataStore[0].threadState = ENKI_THREAD_STATE_PRIMARY_REGISTERED;
+    gtl_threadNum = 0;
+
+    for( uint32_t thread = GetNumFirstExternalTaskThread(); thread < m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); ++thread )
     {
-        m_pThreadDataStore[thread].threadState   = THREAD_STATE_EXTERNAL_UNREGISTERED;
+        m_pThreadDataStore[thread].threadState   = ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED;
     }
-    for( uint32_t thread = m_Config.numExternalTaskThreads + 1; thread < m_NumThreads; ++thread )
+    for( uint32_t thread = m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
     {
-        m_pThreadDataStore[thread].threadState   = THREAD_STATE_NOT_LAUNCHED;
+        m_pThreadDataStore[thread].threadState   = ENKI_THREAD_STATE_NOT_LAUNCHED;
     }
+
+
+    // Create Wait New Pinned Task Semaphores and init rndSeed
+    for( uint32_t threadNum = 0; threadNum < m_NumThreads; ++threadNum )
+    {
+        m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore = SemaphoreNew();
+        m_pThreadDataStore[threadNum].rndSeed = threadNum;
+    }
+
     // only launch threads once all thread states are set
-    for( uint32_t thread = m_Config.numExternalTaskThreads + 1; thread < m_NumThreads; ++thread )
+    for( uint32_t thread = m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
     {
         m_pThreads[thread]                       = std::thread( TaskingThreadFunction, ThreadArgs{ thread, this } );
         ++m_NumInternalTaskThreadsRunning;
     }
 
     // ensure we have sufficient tasks to equally fill either all threads including main
-    // or just the threads we've launched, this is outside the firstinit as we want to be able
+    // or just the threads we've launched, this is outside the first init as we want to be able
     // to runtime change it
     if( 1 == m_NumThreads )
     {
@@ -314,33 +385,103 @@ void TaskScheduler::StartThreads()
         // We only need to partition for a maximum of the available processor parallelism.
         uint32_t numThreadsToPartitionFor = std::min( m_NumThreads, GetNumHardwareThreads() );
         m_NumPartitions = numThreadsToPartitionFor * (numThreadsToPartitionFor - 1);
-        m_NumInitialPartitions = numThreadsToPartitionFor - 1;
-        if( m_NumInitialPartitions > gc_MaxNumInitialPartitions )
+        // ensure m_NumPartitions, m_NumInitialPartitions non zero, can happen if m_NumThreads > 1 && GetNumHardwareThreads() == 1
+        m_NumPartitions        = std::max( m_NumPartitions,              (uint32_t)1 );
+        m_NumInitialPartitions = std::max( numThreadsToPartitionFor - 1, (uint32_t)1 );
+        m_NumInitialPartitions = std::min( m_NumInitialPartitions, gc_MaxNumInitialPartitions );
+    }
+
+#ifdef ENKI_USE_WINDOWS_PROCESSOR_API
+    // x64 bit Windows may support >64 logical processors using processor groups, and only allocate threads to a default group.
+    // We need to detect this and distribute threads accordingly
+    if( GetNumHardwareThreads() > 64 &&                                    // only have processor groups if > 64 hardware threads
+        std::thread::hardware_concurrency() < GetNumHardwareThreads() &&   // if std::thread sees > 64 hardware threads no need to distribute
+        std::thread::hardware_concurrency() < m_NumThreads )               // no need to distribute if number of threads requested lower than std::thread sees
+    {
+        uint32_t numProcessorGroups = GetActiveProcessorGroupCount();
+        GROUP_AFFINITY mainThreadAffinity;
+        BOOL success = GetThreadGroupAffinity( GetCurrentThread(), &mainThreadAffinity );
+        ENKI_ASSERT( success );
+        if( success )
         {
-            m_NumInitialPartitions = gc_MaxNumInitialPartitions;
+            uint32_t mainProcessorGroup = mainThreadAffinity.Group;
+            uint32_t currLogicalProcess = GetActiveProcessorCount( (WORD)mainProcessorGroup ); // we start iteration at end of current process group's threads
+
+            // If more threads are created than there are logical processors then we still want to distribute them evenly amongst groups
+            // so we iterate continuously around the groups until we reach m_NumThreads
+            uint32_t group = 0;
+            while( currLogicalProcess < m_NumThreads )
+            {
+                ++group; // start at group 1 since we set currLogicalProcess to start of next group
+                uint32_t currGroup = ( group + mainProcessorGroup ) % numProcessorGroups; // we start at mainProcessorGroup, go round in circles
+                uint32_t groupNumLogicalProcessors = GetActiveProcessorCount( (WORD)currGroup );
+                ENKI_ASSERT( groupNumLogicalProcessors <= 64 );
+                uint64_t GROUPMASK = 0xFFFFFFFFFFFFFFFFULL >> (64-groupNumLogicalProcessors); // group mask should not have 1's where there are no processors
+                for( uint32_t groupLogicalProcess = 0; ( groupLogicalProcess < groupNumLogicalProcessors ) && ( currLogicalProcess < m_NumThreads ); ++groupLogicalProcess, ++currLogicalProcess )
+                {
+                    if( currLogicalProcess > m_Config.numExternalTaskThreads + GetNumFirstExternalTaskThread() )
+                    {
+                        auto thread_handle = m_pThreads[currLogicalProcess].native_handle();
+
+                        // From https://learn.microsoft.com/en-us/windows/win32/procthread/processor-groups
+                        // If a thread is assigned to a different group than the process, the process's affinity is updated to include the thread's affinity
+                        // and the process becomes a multi-group process.
+                        GROUP_AFFINITY threadAffinity;
+                        success = GetThreadGroupAffinity( thread_handle, &threadAffinity );
+                        ENKI_ASSERT(success); (void)success;
+                        if( threadAffinity.Group != currGroup )
+                        {
+                            threadAffinity.Group = (WORD)currGroup;
+                            threadAffinity.Mask  = GROUPMASK;
+                            success = SetThreadGroupAffinity( thread_handle, &threadAffinity, nullptr );
+                            ENKI_ASSERT( success ); (void)success;
+                        }
+                    }
+                }
+            }
         }
     }
+#endif
 
     m_bHaveThreads = true;
 }
 
 void TaskScheduler::StopThreads( bool bWait_ )
 {
+    // we set m_bWaitforAllCalled to true to ensure any task which loop using this status exit
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+
+    // set status
+    m_bShutdownRequested.store( true, std::memory_order_release );
+    m_bRunning.store( false, std::memory_order_release );
+
     if( m_bHaveThreads )
     {
-        // wait for them threads quit before deleting data
-        m_bRunning = 0;
+
+        // wait for threads to quit before deleting data
         while( bWait_ && m_NumInternalTaskThreadsRunning )
         {
             // keep firing event to ensure all threads pick up state of m_bRunning
            WakeThreadsForNewTasks();
+
+           for( uint32_t threadId = 0; threadId < m_NumThreads; ++threadId )
+           {
+               // send wait for new pinned tasks signal to ensure any waiting are awoken
+               SemaphoreSignal( *m_pThreadDataStore[ threadId ].pWaitNewPinnedTaskSemaphore, 1 );
+           }
         }
 
-        // detach threads starting with thread 1 (as 0 is initialization thread).
-        for( uint32_t thread = m_Config.numExternalTaskThreads + 1; thread < m_NumThreads; ++thread )
+        // detach threads starting with thread GetNumFirstExternalTaskThread() (as 0 is initialization thread).
+        for( uint32_t thread = m_Config.numExternalTaskThreads +  GetNumFirstExternalTaskThread(); thread < m_NumThreads; ++thread )
         {
-            assert( m_pThreads[thread].joinable() );
+            ENKI_ASSERT( m_pThreads[thread].joinable() );
             m_pThreads[thread].join();
+        }
+
+        // delete any Wait New Pinned Task Semaphores
+        for( uint32_t threadNum = 0; threadNum < m_NumThreads; ++threadNum )
+        {
+            SemaphoreDelete( m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore );
         }
 
         DeleteArray( m_pThreadDataStore, m_NumThreads, ENKI_FILE_AND_LINE );
@@ -382,6 +523,39 @@ bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t& hintPipeToCheck_i
     return false;
 }
 
+static inline uint32_t RotateLeft( uint32_t value, int32_t count )
+{
+    return ( value << count ) | ( value >> ( 32 - count ));
+}
+/*  xxHash variant based on documentation on
+    https://github.com/Cyan4973/xxHash/blob/eec5700f4d62113b47ee548edbc4746f61ffb098/doc/xxhash_spec.md
+
+    Copyright (c) Yann Collet
+
+    Permission is granted to copy and distribute this document for any purpose and without charge, including translations into other languages and incorporation into compilations, provided that the copyright notice and this notice are preserved, and that any substantive changes or deletions from the original are clearly marked. Distribution of this document is unlimited.
+*/
+static inline uint32_t Hash32( uint32_t in_ )
+{
+    static const uint32_t PRIME32_1 = 2654435761U;  // 0b10011110001101110111100110110001
+    static const uint32_t PRIME32_2 = 2246822519U;  // 0b10000101111010111100101001110111
+    static const uint32_t PRIME32_3 = 3266489917U;  // 0b11000010101100101010111000111101
+    static const uint32_t PRIME32_4 =  668265263U;  // 0b00100111110101001110101100101111
+    static const uint32_t PRIME32_5 =  374761393U;  // 0b00010110010101100110011110110001
+    static const uint32_t SEED      = 0; // can configure seed if needed
+
+    // simple hash of nodes, does not check if nodePool is compressed or not.
+    uint32_t acc = SEED + PRIME32_5;
+
+    // add node types to map, and also ensure that fully empty nodes are well distributed by hashing the pointer.
+    acc += in_;
+    acc = acc ^ (acc >> 15);
+    acc = acc * PRIME32_2;
+    acc = acc ^ (acc >> 13);
+    acc = acc * PRIME32_3;
+    acc = acc ^ (acc >> 16);
+    return acc;
+}
+
 bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_t& hintPipeToCheck_io_ )
 {
     // Run any tasks for this thread
@@ -391,18 +565,31 @@ bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_
     SubTaskSet subTask;
     bool bHaveTask = m_pPipesPerThread[ priority_ ][ threadNum_ ].WriterTryReadFront( &subTask );
 
-    uint32_t threadToCheck = hintPipeToCheck_io_;
+    uint32_t threadToCheckStart = hintPipeToCheck_io_ % m_NumThreads;
+    uint32_t threadToCheck      = threadToCheckStart;
     uint32_t checkCount = 0;
-    while( !bHaveTask && checkCount < m_NumThreads )
+    if( !bHaveTask )
     {
-        threadToCheck = ( hintPipeToCheck_io_ + checkCount ) % m_NumThreads;
-        if( threadToCheck != threadNum_ )
+        bHaveTask = m_pPipesPerThread[ priority_ ][ threadToCheck ].ReaderTryReadBack( &subTask );
+        if( !bHaveTask )
         {
-            bHaveTask = m_pPipesPerThread[ priority_ ][ threadToCheck ].ReaderTryReadBack( &subTask );
+            // To prevent many threads checking the same task pipe for work we pseudorandomly distribute
+            // the starting thread which we start checking for tasks to run
+            uint32_t& rndSeed = m_pThreadDataStore[threadNum_].rndSeed;
+            ++rndSeed;
+            uint32_t threadToCheckOffset = Hash32( rndSeed * threadNum_ );
+            while( !bHaveTask && checkCount < m_NumThreads )
+            {
+                threadToCheck = ( threadToCheckOffset + checkCount ) % m_NumThreads;
+                if( threadToCheck != threadNum_ && threadToCheckOffset != threadToCheckStart )
+                {
+                    bHaveTask = m_pPipesPerThread[ priority_ ][ threadToCheck ].ReaderTryReadBack( &subTask );
+                }
+                ++checkCount;
+            }
         }
-        ++checkCount;
     }
-        
+
     if( bHaveTask )
     {
         // update hint, will preserve value unless actually got task from another thread.
@@ -412,30 +599,77 @@ bool TaskScheduler::TryRunTask( uint32_t threadNum_, uint32_t priority_, uint32_
         if( subTask.pTask->m_RangeToRun < partitionSize )
         {
             SubTaskSet taskToRun = SplitTask( subTask, subTask.pTask->m_RangeToRun );
-            SplitAndAddTask( threadNum_, subTask, subTask.pTask->m_RangeToRun );
-            taskToRun.pTask->ExecuteRange( taskToRun.partition, threadNum_ );
-            int prevCount = taskToRun.pTask->m_RunningCount.fetch_sub(1,std::memory_order_release );
-            if( 1 == prevCount  &&
-                taskToRun.pTask->m_WaitingForTaskCount.load( std::memory_order_acquire ) )
+            uint32_t rangeToSplit = subTask.pTask->m_RangeToRun;
+            if( threadNum_ != threadToCheck )
             {
-                WakeThreadsForTaskCompletion();
+                // task was stolen from another thread
+                // in order to ensure other threads can get enough work we need to split into larger ranges
+                // these larger splits are then stolen and split themselves
+                // otherwise other threads must keep stealing from this thread, which may stall when pipe is full
+                rangeToSplit = std::max( rangeToSplit, (subTask.partition.end - subTask.partition.start) / gc_MaxStolenPartitions );
+            }
+            SplitAndAddTask( threadNum_, subTask, rangeToSplit );
+            taskToRun.pTask->ExecuteRange( taskToRun.partition, threadNum_ );
+            int prevCount = taskToRun.pTask->m_RunningCount.fetch_sub(1,std::memory_order_acq_rel );
+            if( gc_TaskStartCount == prevCount )
+            {
+                TaskComplete( taskToRun.pTask, true, threadNum_ );
             }
         }
         else
         {
             // the task has already been divided up by AddTaskSetToPipe, so just run it
             subTask.pTask->ExecuteRange( subTask.partition, threadNum_ );
-            int prevCount = subTask.pTask->m_RunningCount.fetch_sub(1,std::memory_order_release );
-            if( 1 == prevCount && 
-                subTask.pTask->m_WaitingForTaskCount.load( std::memory_order_acquire ) )
+            int prevCount = subTask.pTask->m_RunningCount.fetch_sub(1,std::memory_order_acq_rel );
+            if( gc_TaskStartCount == prevCount )
             {
-                WakeThreadsForTaskCompletion();
+                TaskComplete( subTask.pTask, true, threadNum_ );
             }
         }
     }
 
     return bHaveTask;
 
+}
+
+void TaskScheduler::TaskComplete( ICompletable* pTask_, bool bWakeThreads_, uint32_t threadNum_ )
+{
+    // It must be impossible for a thread to enter the sleeping wait prior to the load of m_WaitingForTaskCount
+    // in this function, so we introduce a gc_TaskAlmostCompleteCount to prevent this.
+    ENKI_ASSERT( gc_TaskAlmostCompleteCount == pTask_->m_RunningCount.load( std::memory_order_acquire ) );
+    bool bCallWakeThreads = bWakeThreads_ && pTask_->m_WaitingForTaskCount.load( std::memory_order_acquire );
+
+    Dependency* pDependent = pTask_->m_pDependents;
+
+    // Do not access pTask_ below this line unless we have dependencies.
+    pTask_->m_RunningCount.store( 0, std::memory_order_release );
+
+    if( bCallWakeThreads )
+    {
+        WakeThreadsForTaskCompletion();
+    }
+
+    while( pDependent )
+    {
+        // access pTaskToRunOnCompletion member data before incrementing m_DependenciesCompletedCount so
+        // they do not get deleted when another thread completes the pTaskToRunOnCompletion
+        int32_t dependenciesCount  = pDependent->pTaskToRunOnCompletion->m_DependenciesCount;
+        // get temp copy of pDependent so OnDependenciesComplete can delete task if needed.
+        Dependency* pDependentCurr = pDependent;
+        pDependent                 = pDependent->pNext;
+        int32_t prevDeps = pDependentCurr->pTaskToRunOnCompletion->m_DependenciesCompletedCount.fetch_add( 1, std::memory_order_release );
+        ENKI_ASSERT( prevDeps < dependenciesCount );
+        if( dependenciesCount == ( prevDeps + 1 ) )
+        {
+            // reset dependencies
+            // only safe to access pDependentCurr here after above fetch_add because this is the thread
+            // which calls OnDependenciesComplete after store with memory_order_release
+            pDependentCurr->pTaskToRunOnCompletion->m_DependenciesCompletedCount.store(
+                0,
+                std::memory_order_release );
+            pDependentCurr->pTaskToRunOnCompletion->OnDependenciesComplete( this, threadNum_ );
+        }
+    }
 }
 
 bool TaskScheduler::HaveTasks(  uint32_t threadNum_ )
@@ -462,19 +696,19 @@ void TaskScheduler::WaitForNewTasks( uint32_t threadNum_ )
     // We don't want to suspend this thread if there are task threads
     // with pinned tasks suspended, as it could result in this thread
     // being unsuspended and not the thread with pinned tasks
-    if( WakeSuspendedThreadsWithPinnedTasks() )
+    if( WakeSuspendedThreadsWithPinnedTasks( threadNum_ ) )
     {
         return;
     }
 
-    // We incrememt the number of threads waiting here in order
+    // We increment the number of threads waiting here in order
     // to ensure that the check for tasks occurs after the increment
     // to prevent a task being added after a check, then the thread waiting.
     // This will occasionally result in threads being mistakenly awoken,
     // but they will then go back to sleep.
     m_NumThreadsWaitingForNewTasks.fetch_add( 1, std::memory_order_acquire );
     ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
-    m_pThreadDataStore[threadNum_].threadState.store( THREAD_STATE_WAIT_NEW_TASKS, std::memory_order_seq_cst );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_WAIT_NEW_TASKS, std::memory_order_seq_cst );
 
     if( HaveTasks( threadNum_ ) )
     {
@@ -495,19 +729,20 @@ void TaskScheduler::WaitForTaskCompletion( const ICompletable* pCompletable_, ui
     // We don't want to suspend this thread if there are task threads
     // with pinned tasks suspended, as the completable could be a pinned task
     // or it could be waiting on one.
-    if( WakeSuspendedThreadsWithPinnedTasks() )
+    if( WakeSuspendedThreadsWithPinnedTasks( threadNum_ ) )
     {
         return;
     }
 
-    m_NumThreadsWaitingForTaskCompletion.fetch_add( 1, std::memory_order_acquire );
-    pCompletable_->m_WaitingForTaskCount.fetch_add( 1, std::memory_order_acquire );
+    m_NumThreadsWaitingForTaskCompletion.fetch_add( 1, std::memory_order_acq_rel );
+    pCompletable_->m_WaitingForTaskCount.fetch_add( 1, std::memory_order_acq_rel );
     ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
-    m_pThreadDataStore[threadNum_].threadState.store( THREAD_STATE_WAIT_TASK_COMPLETION, std::memory_order_seq_cst );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_WAIT_TASK_COMPLETION, std::memory_order_seq_cst );
 
-    if( pCompletable_->GetIsComplete() || HaveTasks( threadNum_ ) )
+    // do not wait on semaphore if task in gc_TaskAlmostCompleteCount state.
+    if( gc_TaskAlmostCompleteCount >= pCompletable_->m_RunningCount.load( std::memory_order_acquire ) || HaveTasks( threadNum_ ) )
     {
-        m_NumThreadsWaitingForTaskCompletion.fetch_sub( 1, std::memory_order_release );
+        m_NumThreadsWaitingForTaskCompletion.fetch_sub( 1, std::memory_order_acq_rel );
     }
     else
     {
@@ -524,7 +759,7 @@ void TaskScheduler::WaitForTaskCompletion( const ICompletable* pCompletable_, ui
     }
 
     m_pThreadDataStore[threadNum_].threadState.store( prevThreadState, std::memory_order_release );
-    pCompletable_->m_WaitingForTaskCount.fetch_sub( 1, std::memory_order_release );
+    pCompletable_->m_WaitingForTaskCount.fetch_sub( 1, std::memory_order_acq_rel );
 }
 
 void TaskScheduler::WakeThreadsForNewTasks()
@@ -554,19 +789,18 @@ void TaskScheduler::WakeThreadsForTaskCompletion()
     }
 }
 
-bool TaskScheduler::WakeSuspendedThreadsWithPinnedTasks()
+bool TaskScheduler::WakeSuspendedThreadsWithPinnedTasks( uint32_t threadNum_ )
 {
-    uint32_t threadNum = gtl_threadNum;
     for( uint32_t t = 1; t < m_NumThreads; ++t )
     {
         // distribute thread checks more evenly by starting at our thread number rather than 0.
-        uint32_t thread = ( threadNum + t ) % m_NumThreads;
+        uint32_t thread = ( threadNum_ + t ) % m_NumThreads;
 
         ThreadState state = m_pThreadDataStore[ thread ].threadState.load( std::memory_order_acquire );
-            
-        assert( state != THREAD_STATE_NONE );
 
-        if( state == THREAD_STATE_WAIT_NEW_TASKS || state == THREAD_STATE_WAIT_TASK_COMPLETION )
+        ENKI_ASSERT( state != ENKI_THREAD_STATE_NONE );
+
+        if( state == ENKI_THREAD_STATE_WAIT_NEW_TASKS || state == ENKI_THREAD_STATE_WAIT_TASK_COMPLETION )
         {
             // thread is suspended, check if it has pinned tasks
             for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
@@ -585,34 +819,45 @@ bool TaskScheduler::WakeSuspendedThreadsWithPinnedTasks()
 void TaskScheduler::SplitAndAddTask( uint32_t threadNum_, SubTaskSet subTask_, uint32_t rangeToSplit_ )
 {
     int32_t numAdded = 0;
+    int32_t numNewTasksSinceNotification = 0;
     int32_t numRun   = 0;
+
+    int32_t upperBoundNumToAdd = 2 + (int32_t)( ( subTask_.partition.end - subTask_.partition.start ) / rangeToSplit_ );
+
     // ensure that an artificial completion is not registered whilst adding tasks by incrementing count
-    subTask_.pTask->m_RunningCount.fetch_add( 1, std::memory_order_acquire );
+    subTask_.pTask->m_RunningCount.fetch_add( upperBoundNumToAdd, std::memory_order_acquire );
     while( subTask_.partition.start != subTask_.partition.end )
     {
         SubTaskSet taskToAdd = SplitTask( subTask_, rangeToSplit_ );
 
         // add the partition to the pipe
-        ++numAdded;
-        subTask_.pTask->m_RunningCount.fetch_add( 1, std::memory_order_acquire );
+        ++numAdded; ++numNewTasksSinceNotification;
         if( !m_pPipesPerThread[ subTask_.pTask->m_Priority ][ threadNum_ ].WriterTryWriteFront( taskToAdd ) )
         {
-            if( numAdded > 1 )
+            --numAdded; // we were unable to add the task
+            if( numNewTasksSinceNotification > 1 )
             {
                 WakeThreadsForNewTasks();
             }
-            numAdded = 0;
+            numNewTasksSinceNotification = 0;
             // alter range to run the appropriate fraction
-            if( taskToAdd.pTask->m_RangeToRun < rangeToSplit_ )
+            if( taskToAdd.pTask->m_RangeToRun < taskToAdd.partition.end - taskToAdd.partition.start )
             {
                 taskToAdd.partition.end = taskToAdd.partition.start + taskToAdd.pTask->m_RangeToRun;
+                ENKI_ASSERT( taskToAdd.partition.end <= taskToAdd.pTask->m_SetSize );
                 subTask_.partition.start = taskToAdd.partition.end;
             }
             taskToAdd.pTask->ExecuteRange( taskToAdd.partition, threadNum_ );
             ++numRun;
         }
     }
-    subTask_.pTask->m_RunningCount.fetch_sub( numRun + 1, std::memory_order_release );
+    int32_t countToRemove = upperBoundNumToAdd - numAdded;
+    ENKI_ASSERT( countToRemove > 0 );
+    int prevCount = subTask_.pTask->m_RunningCount.fetch_sub( countToRemove, std::memory_order_acq_rel );
+    if( countToRemove-1 + gc_TaskStartCount == prevCount )
+    {
+        TaskComplete( subTask_.pTask, false, threadNum_ );
+    }
 
     // WakeThreadsForNewTasks also calls WakeThreadsForTaskCompletion() so do not need to do so above
     WakeThreadsForNewTasks();
@@ -623,48 +868,93 @@ TaskSchedulerConfig TaskScheduler::GetConfig() const
     return m_Config;
 }
 
-void    TaskScheduler::AddTaskSetToPipe( ITaskSet* pTaskSet_ )
+void TaskScheduler::AddTaskSetToPipeInt( ITaskSet* pTaskSet_, uint32_t threadNum_ )
 {
-    assert( pTaskSet_->m_RunningCount == 0 );
-    uint32_t threadNum = gtl_threadNum;
-
-    ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
-    m_pThreadDataStore[threadNum].threadState.store( THREAD_STATE_RUNNING, std::memory_order_relaxed );
-    pTaskSet_->m_RunningCount.store( 0, std::memory_order_relaxed );
+    ENKI_ASSERT( pTaskSet_->m_RunningCount == gc_TaskStartCount );
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum_].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum_].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
     std::atomic_thread_fence(std::memory_order_acquire);
 
 
     // divide task up and add to pipe
     pTaskSet_->m_RangeToRun = pTaskSet_->m_SetSize / m_NumPartitions;
-    if( pTaskSet_->m_RangeToRun < pTaskSet_->m_MinRange ) { pTaskSet_->m_RangeToRun = pTaskSet_->m_MinRange; }
+    pTaskSet_->m_RangeToRun = std::max( pTaskSet_->m_RangeToRun, pTaskSet_->m_MinRange );
+    // Note: if m_SetSize is < m_RangeToRun this will be handled by SplitTask and so does not need to be handled here
 
     uint32_t rangeToSplit = pTaskSet_->m_SetSize / m_NumInitialPartitions;
-    if( rangeToSplit < pTaskSet_->m_MinRange ) { rangeToSplit = pTaskSet_->m_MinRange; }
+    rangeToSplit = std::max( rangeToSplit, pTaskSet_->m_MinRange );
 
     SubTaskSet subTask;
     subTask.pTask = pTaskSet_;
     subTask.partition.start = 0;
     subTask.partition.end = pTaskSet_->m_SetSize;
-    SplitAndAddTask( threadNum, subTask, rangeToSplit );
+    SplitAndAddTask( threadNum_, subTask, rangeToSplit );
+    int prevCount = pTaskSet_->m_RunningCount.fetch_sub(1, std::memory_order_acq_rel );
+    if( gc_TaskStartCount == prevCount )
+    {
+        TaskComplete( pTaskSet_, true, threadNum_ );
+    }
 
-    m_pThreadDataStore[threadNum].threadState.store( prevThreadState, std::memory_order_release );
+    m_pThreadDataStore[threadNum_].threadState.store( prevThreadState, std::memory_order_release );
+}
 
+void TaskScheduler::AddTaskSetToPipe( ITaskSet* pTaskSet_ )
+{
+    ENKI_ASSERT( pTaskSet_->m_RunningCount == 0 );
+    InitDependencies( pTaskSet_ );
+    pTaskSet_->m_RunningCount.store( gc_TaskStartCount, std::memory_order_relaxed );
+    AddTaskSetToPipeInt( pTaskSet_, gtl_threadNum );
+}
+
+void  TaskScheduler::AddPinnedTaskInt( IPinnedTask* pTask_ )
+{
+    ENKI_ASSERT( pTask_->m_RunningCount == gc_TaskStartCount );
+    m_pPinnedTaskListPerThread[ pTask_->m_Priority ][ pTask_->threadNum ].WriterWriteFront( pTask_ );
+
+    ThreadState statePinnedTaskThread = m_pThreadDataStore[ pTask_->threadNum ].threadState.load( std::memory_order_acquire );
+    if( statePinnedTaskThread == ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS )
+    {
+        SemaphoreSignal( *m_pThreadDataStore[ pTask_->threadNum ].pWaitNewPinnedTaskSemaphore, 1 );
+    }
+    else
+    {
+        WakeThreadsForNewTasks();
+    }
 }
 
 void TaskScheduler::AddPinnedTask( IPinnedTask* pTask_ )
 {
-    assert( pTask_->m_RunningCount == 0 );
-
-    pTask_->m_RunningCount = 1;
-    m_pPinnedTaskListPerThread[ pTask_->m_Priority ][ pTask_->threadNum ].WriterWriteFront( pTask_ );
-    WakeThreadsForNewTasks();
+    ENKI_ASSERT( pTask_->m_RunningCount == 0 );
+    InitDependencies( pTask_ );
+    pTask_->m_RunningCount = gc_TaskStartCount;
+    AddPinnedTaskInt( pTask_ );
 }
+
+void TaskScheduler::InitDependencies( ICompletable* pCompletable_ )
+{
+    // go through any dependencies and set their running count so they show as not complete
+    // and increment dependency count
+    if( pCompletable_->m_RunningCount.load( std::memory_order_relaxed ) )
+    {
+        // already initialized
+        return;
+    }
+    Dependency* pDependent = pCompletable_->m_pDependents;
+    while( pDependent )
+    {
+        InitDependencies( pDependent->pTaskToRunOnCompletion );
+        pDependent->pTaskToRunOnCompletion->m_RunningCount.store( gc_TaskStartCount, std::memory_order_relaxed );
+        pDependent = pDependent->pNext;
+    }
+}
+
 
 void TaskScheduler::RunPinnedTasks()
 {
+    ENKI_ASSERT( gtl_threadNum != enki::NO_THREAD_NUM );
     uint32_t threadNum = gtl_threadNum;
     ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
-    m_pThreadDataStore[threadNum].threadState.store( THREAD_STATE_RUNNING, std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
     std::atomic_thread_fence(std::memory_order_acquire);
     for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
     {
@@ -682,23 +972,21 @@ void TaskScheduler::RunPinnedTasks( uint32_t threadNum_, uint32_t priority_ )
         if( pPinnedTaskSet )
         {
             pPinnedTaskSet->Execute();
-            pPinnedTaskSet->m_RunningCount = 0;
-            if( pPinnedTaskSet->m_WaitingForTaskCount.load( std::memory_order_acquire ) )
-            {
-                WakeThreadsForTaskCompletion();
-            }
+            pPinnedTaskSet->m_RunningCount.fetch_sub(1,std::memory_order_acq_rel);
+            TaskComplete( pPinnedTaskSet, true, threadNum_ );
         }
     } while( pPinnedTaskSet );
 }
 
 void    TaskScheduler::WaitforTask( const ICompletable* pCompletable_, enki::TaskPriority priorityOfLowestToRun_ )
 {
+    ENKI_ASSERT( gtl_threadNum != enki::NO_THREAD_NUM );
     uint32_t threadNum = gtl_threadNum;
     uint32_t hintPipeToCheck_io = threadNum + 1;    // does not need to be clamped.
 
     // waiting for a task is equivalent to 'running' for thread state purpose as we may run tasks whilst waiting
     ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
-    m_pThreadDataStore[threadNum].threadState.store( THREAD_STATE_RUNNING, std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_RUNNING, std::memory_order_relaxed );
     std::atomic_thread_fence(std::memory_order_acquire);
 
 
@@ -709,7 +997,7 @@ void    TaskScheduler::WaitforTask( const ICompletable* pCompletable_, enki::Tas
         // so we clamp the priorityOfLowestToRun_ to no smaller than the task we're waiting for
         priorityOfLowestToRun_ = std::max( priorityOfLowestToRun_, pCompletable_->m_Priority );
         uint32_t spinCount = 0;
-        while( !pCompletable_->GetIsComplete() )
+        while( !pCompletable_->GetIsComplete() && GetIsRunning() )
         {
             ++spinCount;
             for( int priority = 0; priority <= priorityOfLowestToRun_; ++priority )
@@ -727,17 +1015,17 @@ void    TaskScheduler::WaitforTask( const ICompletable* pCompletable_, enki::Tas
             }
             else
             {
-                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+                uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMultiplier;
                 SpinWait( spinBackoffCount );
             }
         }
         SafeCallback( m_Config.profilerCallbacks.waitForTaskCompleteStop, threadNum );
     }
-    else
+    else if( nullptr == pCompletable_ )
     {
             for( int priority = 0; priority <= priorityOfLowestToRun_; ++priority )
             {
-                if( TryRunTask( gtl_threadNum, priority, hintPipeToCheck_io ) )
+                if( TryRunTask( threadNum, priority, hintPipeToCheck_io ) )
                 {
                     break;
                 }
@@ -758,16 +1046,19 @@ class TaskSchedulerWaitTask : public IPinnedTask
 
 void TaskScheduler::WaitforAll()
 {
+    ENKI_ASSERT( gtl_threadNum != enki::NO_THREAD_NUM );
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+
     bool bHaveTasks = true;
-    uint32_t threadNum = gtl_threadNum;
-    uint32_t hintPipeToCheck_io = threadNum  + 1;    // does not need to be clamped.
-    int32_t numOtherThreadsRunning = 0; // account for this thread
+    uint32_t ourThreadNum = gtl_threadNum;
+    uint32_t hintPipeToCheck_io = ourThreadNum  + 1;    // does not need to be clamped.
+    bool otherThreadsRunning = false; // account for this thread
     uint32_t spinCount = 0;
     TaskSchedulerWaitTask dummyWaitTask;
     dummyWaitTask.threadNum = 0;
-    while( bHaveTasks || numOtherThreadsRunning )
+    while( GetIsRunning() && ( bHaveTasks || otherThreadsRunning ) )
     {
-        bHaveTasks = TryRunTask( threadNum, hintPipeToCheck_io );
+        bHaveTasks = TryRunTask( ourThreadNum, hintPipeToCheck_io );
         ++spinCount;
         if( bHaveTasks )
         {
@@ -784,11 +1075,11 @@ void TaskScheduler::WaitforAll()
                 dummyWaitTask.threadNum = ( dummyWaitTask.threadNum + 1 ) % m_NumThreads;
 
                 // We can only add a pinned task to wait on if we find an enki Task Thread which isn't this thread.
-                // Otherwise we have to busy wait.
-                if( dummyWaitTask.threadNum != threadNum && dummyWaitTask.threadNum > m_Config.numExternalTaskThreads )
+                // Otherwise, we have to busy wait.
+                if( dummyWaitTask.threadNum != ourThreadNum && dummyWaitTask.threadNum > m_Config.numExternalTaskThreads )
                 {
                     ThreadState state = m_pThreadDataStore[ dummyWaitTask.threadNum ].threadState.load( std::memory_order_acquire );
-                    if( state == THREAD_STATE_RUNNING || state == THREAD_STATE_WAIT_TASK_COMPLETION )
+                    if( state == ENKI_THREAD_STATE_RUNNING || state == ENKI_THREAD_STATE_WAIT_TASK_COMPLETION )
                     {
                         bHaveThreadToWaitOn = true;
                         break;
@@ -798,7 +1089,7 @@ void TaskScheduler::WaitforAll()
 
             if( bHaveThreadToWaitOn )
             {
-                assert( dummyWaitTask.threadNum != threadNum );
+                ENKI_ASSERT( dummyWaitTask.threadNum != ourThreadNum );
                 AddPinnedTask( &dummyWaitTask );
                 WaitforTask( &dummyWaitTask );
             }
@@ -806,46 +1097,106 @@ void TaskScheduler::WaitforAll()
         }
         else
         {
-            uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMulitplier;
+            uint32_t spinBackoffCount = spinCount * gc_SpinBackOffMultiplier;
             SpinWait( spinBackoffCount );
         }
 
         // count threads running
-        numOtherThreadsRunning = 0;
-        for(uint32_t thread = 0; thread < m_NumThreads; ++thread )
+        otherThreadsRunning = false;
+        for(uint32_t thread = 0; thread < m_NumThreads && !otherThreadsRunning; ++thread )
         {
             // ignore our thread
-            if( thread != threadNum )
+            if( thread != ourThreadNum )
             {
                 switch( m_pThreadDataStore[thread].threadState.load( std::memory_order_acquire ) )
                 {
-                case THREAD_STATE_NONE:
-                    assert(false);
+                case ENKI_THREAD_STATE_NONE:
+                    ENKI_ASSERT(false);
                     break;
-                case THREAD_STATE_NOT_LAUNCHED:
-                case THREAD_STATE_RUNNING:
-                case THREAD_STATE_WAIT_TASK_COMPLETION:
-                    ++numOtherThreadsRunning;
+                case ENKI_THREAD_STATE_NOT_LAUNCHED:
+                case ENKI_THREAD_STATE_RUNNING:
+                case ENKI_THREAD_STATE_WAIT_TASK_COMPLETION:
+                    otherThreadsRunning = true;
                     break;
-                case THREAD_STATE_EXTERNAL_REGISTERED:
-                case THREAD_STATE_EXTERNAL_UNREGISTERED:
-                case THREAD_STATE_WAIT_NEW_TASKS:
-                case THREAD_STATE_STOPPED:
+                case ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS:
+                    otherThreadsRunning = true;
+                    SemaphoreSignal( *m_pThreadDataStore[thread].pWaitNewPinnedTaskSemaphore, 1 );
                     break;
-                 };
+                case ENKI_THREAD_STATE_PRIMARY_REGISTERED:
+                case ENKI_THREAD_STATE_EXTERNAL_REGISTERED:
+                case ENKI_THREAD_STATE_EXTERNAL_UNREGISTERED:
+                case ENKI_THREAD_STATE_WAIT_NEW_TASKS:
+                case ENKI_THREAD_STATE_STOPPED:
+                    break;
+                }
+            }
+        }
+        if( !otherThreadsRunning )
+        {
+            // check there are no tasks
+            for(uint32_t thread = 0; thread < m_NumThreads && !otherThreadsRunning; ++thread )
+            {
+                // ignore our thread
+                if( thread != ourThreadNum )
+                {
+                    otherThreadsRunning = HaveTasks( thread );
+                }
             }
         }
      }
+
+    m_bWaitforAllCalled.store( false, std::memory_order_release );
 }
 
-void    TaskScheduler::WaitforAllAndShutdown()
+void TaskScheduler::WaitforAllAndShutdown()
 {
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+    m_bShutdownRequested.store( true, std::memory_order_release );
     if( m_bHaveThreads )
     {
         WaitforAll();
         StopThreads(true);
     }
 }
+
+void TaskScheduler::ShutdownNow()
+{
+    m_bWaitforAllCalled.store( true, std::memory_order_release );
+    m_bShutdownRequested.store( true, std::memory_order_release );
+    if( m_bHaveThreads )
+    {
+        StopThreads(true);
+    }
+}
+
+void TaskScheduler::WaitForNewPinnedTasks()
+{
+    ENKI_ASSERT( gtl_threadNum != enki::NO_THREAD_NUM );
+    uint32_t threadNum = gtl_threadNum;
+    ThreadState prevThreadState = m_pThreadDataStore[threadNum].threadState.load( std::memory_order_relaxed );
+    m_pThreadDataStore[threadNum].threadState.store( ENKI_THREAD_STATE_WAIT_NEW_PINNED_TASKS, std::memory_order_seq_cst );
+
+    // check if have tasks inside threadState change but before waiting
+    bool bHavePinnedTasks = false;
+    for( int priority = 0; priority < TASK_PRIORITY_NUM; ++priority )
+    {
+        if( !m_pPinnedTaskListPerThread[ priority ][ threadNum ].IsListEmpty() )
+        {
+            bHavePinnedTasks = true;
+            break;
+        }
+    }
+
+    if( !bHavePinnedTasks )
+    {
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStart, threadNum );
+        SemaphoreWait( *m_pThreadDataStore[threadNum].pWaitNewPinnedTaskSemaphore );
+        SafeCallback( m_Config.profilerCallbacks.waitForNewTaskSuspendStop, threadNum );
+    }
+
+    m_pThreadDataStore[threadNum].threadState.store( prevThreadState, std::memory_order_release );
+}
+
 
 uint32_t        TaskScheduler::GetNumTaskThreads() const
 {
@@ -862,14 +1213,14 @@ template<typename T>
 T* TaskScheduler::NewArray( size_t num_, const char* file_, int line_  )
 {
     T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), num_*sizeof(T), m_Config.customAllocator.userData, file_, line_ );
-    if( !std::is_pod<T>::value )
+    if( !std::is_trivial<T>::value )
     {
-		T* pCurr = pRet;
+        T* pCurr = pRet;
         for( size_t i = 0; i < num_; ++i )
         {
-			void* pBuffer = pCurr;
+            void* pBuffer = pCurr;
             pCurr = new(pBuffer) T;
-			++pCurr;
+            ++pCurr;
         }
     }
     return pRet;
@@ -878,7 +1229,7 @@ T* TaskScheduler::NewArray( size_t num_, const char* file_, int line_  )
 template<typename T>
 void TaskScheduler::DeleteArray( T* p_, size_t num_, const char* file_, int line_ )
 {
-    if( !std::is_pod<T>::value )
+    if( !std::is_trivially_destructible<T>::value )
     {
         size_t i = num_;
         while(i)
@@ -892,14 +1243,27 @@ void TaskScheduler::DeleteArray( T* p_, size_t num_, const char* file_, int line
 template<class T, class... Args>
 T* TaskScheduler::New( const char* file_, int line_, Args&&... args_ )
 {
-    T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), sizeof(T), m_Config.customAllocator.userData, file_, line_ );
+    T* pRet = this->Alloc<T>( file_, line_ );
     return new(pRet) T( std::forward<Args>(args_)... );
 }
 
 template< typename T >
 void TaskScheduler::Delete( T* p_, const char* file_, int line_  )
 {
-    p_->~T(); 
+    p_->~T();
+    this->Free(p_, file_, line_ );
+}
+
+template< typename T >
+T* TaskScheduler::Alloc( const char* file_, int line_  )
+{
+    T* pRet = (T*)m_Config.customAllocator.alloc( alignof(T), sizeof(T), m_Config.customAllocator.userData, file_, line_ );
+    return pRet;
+}
+
+template< typename T >
+void TaskScheduler::Free( T* p_, const char* file_, int line_  )
+{
     m_Config.customAllocator.free( p_, sizeof(T), m_Config.customAllocator.userData, file_, line_ );
 }
 
@@ -909,7 +1273,7 @@ TaskScheduler::TaskScheduler()
         , m_NumThreads(0)
         , m_pThreadDataStore(NULL)
         , m_pThreads(NULL)
-        , m_bRunning(0)
+        , m_bRunning(false)
         , m_NumInternalTaskThreadsRunning(0)
         , m_NumThreadsWaitingForNewTasks(0)
         , m_NumThreadsWaitingForTaskCompletion(0)
@@ -929,7 +1293,7 @@ TaskScheduler::~TaskScheduler()
 
 void TaskScheduler::Initialize( uint32_t numThreadsTotal_ )
 {
-    assert( numThreadsTotal_ >= 1 );
+    ENKI_ASSERT( numThreadsTotal_ >= 1 );
     StopThreads( true ); // Stops threads, waiting for them.
     m_Config.numTaskThreadsToCreate = numThreadsTotal_ - 1;
     m_Config.numExternalTaskThreads = 0;
@@ -956,7 +1320,7 @@ void TaskScheduler::Initialize()
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <Windows.h>
+#include <windows.h>
 
 namespace enki
 {
@@ -964,7 +1328,7 @@ namespace enki
     {
         HANDLE      sem;
     };
-    
+
     inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
     {
 #ifdef _XBOX_ONE
@@ -982,8 +1346,8 @@ namespace enki
     inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
     {
         DWORD retval = WaitForSingleObject( semaphoreid.sem, INFINITE );
-        assert( retval != WAIT_FAILED );
-        (void)retval; // only needed for assert
+        ENKI_ASSERT( retval != WAIT_FAILED );
+        (void)retval; // only needed for ENKI_ASSERT
     }
 
     inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
@@ -999,7 +1363,7 @@ namespace enki
 
 // OS X does not have POSIX semaphores
 // Mach semaphores can now only be created by the kernel
-// Named sempahores work, but would require unique name construction to ensure
+// Named semaphores work, but would require unique name construction to ensure
 // they are isolated to this process.
 // Dispatch semaphores appear to be the way other developers use OSX Semaphores, e.g. Boost
 // However the API could change
@@ -1009,27 +1373,27 @@ namespace enki
 
 namespace enki
 {
-    
+
     struct semaphoreid_t
     {
         dispatch_semaphore_t   sem;
     };
-    
+
     inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
     {
         semaphoreid.sem = dispatch_semaphore_create(0);
     }
-    
+
     inline void SemaphoreClose( semaphoreid_t& semaphoreid )
     {
         dispatch_release( semaphoreid.sem );
     }
-    
+
     inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
     {
         dispatch_semaphore_wait( semaphoreid.sem, DISPATCH_TIME_FOREVER );
     }
-    
+
     inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
     {
         while( countWaiting-- > 0 )
@@ -1046,28 +1410,29 @@ namespace enki
 
 namespace enki
 {
-    
+
     struct semaphoreid_t
     {
         sem_t   sem;
     };
-    
+
     inline void SemaphoreCreate( semaphoreid_t& semaphoreid )
     {
         int err = sem_init( &semaphoreid.sem, 0, 0 );
-        assert( err == 0 );
+        ENKI_ASSERT( err == 0 );
+        (void)err;
     }
-    
+
     inline void SemaphoreClose( semaphoreid_t& semaphoreid )
     {
         sem_destroy( &semaphoreid.sem );
     }
-    
+
     inline void SemaphoreWait( semaphoreid_t& semaphoreid  )
     {
         while( sem_wait( &semaphoreid.sem ) == -1 && errno == EINTR ) {}
     }
-    
+
     inline void SemaphoreSignal( semaphoreid_t& semaphoreid, int32_t countWaiting )
     {
         while( countWaiting-- > 0 )
@@ -1078,10 +1443,9 @@ namespace enki
 }
 #endif
 
-
 semaphoreid_t* TaskScheduler::SemaphoreNew()
 {
-    semaphoreid_t* pSemaphore = New<semaphoreid_t>( ENKI_FILE_AND_LINE );
+    semaphoreid_t* pSemaphore = this->Alloc<semaphoreid_t>( ENKI_FILE_AND_LINE );
     SemaphoreCreate( *pSemaphore );
     return pSemaphore;
 }
@@ -1089,10 +1453,95 @@ semaphoreid_t* TaskScheduler::SemaphoreNew()
 void TaskScheduler::SemaphoreDelete( semaphoreid_t* pSemaphore_ )
 {
     SemaphoreClose( *pSemaphore_ );
-    Delete( pSemaphore_, ENKI_FILE_AND_LINE );
+    this->Free( pSemaphore_, ENKI_FILE_AND_LINE );
 }
 
 void TaskScheduler::SetCustomAllocator( CustomAllocator customAllocator_ )
 {
     m_Config.customAllocator = customAllocator_;
+}
+
+Dependency::Dependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ )
+    : pTaskToRunOnCompletion( pTaskToRunOnCompletion_ )
+    , pDependencyTask( pDependencyTask_ )
+    , pNext( pDependencyTask->m_pDependents )
+{
+    ENKI_ASSERT( pDependencyTask->GetIsComplete() );
+    ENKI_ASSERT( pTaskToRunOnCompletion->GetIsComplete() );
+    pDependencyTask->m_pDependents = this;
+    ++pTaskToRunOnCompletion->m_DependenciesCount;
+}
+
+Dependency::Dependency( Dependency&& rhs_ ) noexcept
+{
+    pDependencyTask   = rhs_.pDependencyTask;
+    pTaskToRunOnCompletion = rhs_.pTaskToRunOnCompletion;
+    pNext             = rhs_.pNext;
+    if( rhs_.pDependencyTask )
+    {
+        ENKI_ASSERT( rhs_.pTaskToRunOnCompletion );
+        ENKI_ASSERT( rhs_.pDependencyTask->GetIsComplete() );
+        ENKI_ASSERT( rhs_.pTaskToRunOnCompletion->GetIsComplete() );
+        Dependency** ppDependent = &(pDependencyTask->m_pDependents);
+        while( *ppDependent )
+        {
+            if( &rhs_ == *ppDependent )
+            {
+                *ppDependent = this;
+                break;
+            }
+            ppDependent = &((*ppDependent)->pNext);
+        }
+    }
+}
+
+
+Dependency::~Dependency()
+{
+    ClearDependency();
+}
+
+void Dependency::SetDependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ )
+{
+    ClearDependency();
+    ENKI_ASSERT( pDependencyTask_->GetIsComplete() );
+    ENKI_ASSERT( pTaskToRunOnCompletion_->GetIsComplete() );
+    pDependencyTask = pDependencyTask_;
+    pTaskToRunOnCompletion = pTaskToRunOnCompletion_;
+    pNext = pDependencyTask->m_pDependents;
+    pDependencyTask->m_pDependents = this;
+    ++pTaskToRunOnCompletion->m_DependenciesCount;
+}
+
+void Dependency::ClearDependency()
+{
+    if( pDependencyTask )
+    {
+        ENKI_ASSERT( pTaskToRunOnCompletion );
+        ENKI_ASSERT( pDependencyTask->GetIsComplete() );
+        ENKI_ASSERT( pTaskToRunOnCompletion->GetIsComplete() );
+        ENKI_ASSERT( pTaskToRunOnCompletion->m_DependenciesCount > 0 );
+        Dependency* pDependent = pDependencyTask->m_pDependents;
+        --pTaskToRunOnCompletion->m_DependenciesCount;
+        if( this == pDependent )
+        {
+            pDependencyTask->m_pDependents = pDependent->pNext;
+        }
+        else
+        {
+            while( pDependent )
+            {
+                Dependency* pPrev = pDependent;
+                pDependent = pDependent->pNext;
+                if( this == pDependent )
+                {
+                    pPrev->pNext = pDependent->pNext;
+                    break;
+                }
+            }
+        }
+    }
+    pDependencyTask = NULL;
+    pDependencyTask =  NULL;
+    pNext = NULL;
 }

--- a/src/external/enkiTS/TaskScheduler.h
+++ b/src/external/enkiTS/TaskScheduler.h
@@ -1,13 +1,13 @@
 // Copyright (c) 2013 Doug Binks
-// 
+//
 // This software is provided 'as-is', without any express or implied
 // warranty. In no event will the authors be held liable for any damages
 // arising from the use of this software.
-// 
+//
 // Permission is granted to anyone to use this software for any purpose,
 // including commercial applications, and to alter it and redistribute it
 // freely, subject to the following restrictions:
-// 
+//
 // 1. The origin of this software must not be misrepresented; you must not
 //    claim that you wrote the original software. If you use this software
 //    in a product, an acknowledgement in the product documentation would be
@@ -20,10 +20,9 @@
 
 #include <atomic>
 #include <thread>
-#include <condition_variable>
 #include <stdint.h>
 #include <functional>
-#include <assert.h>
+#include <initializer_list>
 
 // ENKITS_TASK_PRIORITIES_NUM can be set from 1 to 5.
 // 1 corresponds to effectively no priorities.
@@ -31,6 +30,7 @@
     #define ENKITS_TASK_PRIORITIES_NUM 3
 #endif
 
+#ifndef ENKITS_API
 #if   defined(_WIN32) && defined(ENKITS_BUILD_DLL)
     // Building enkiTS as a DLL
     #define ENKITS_API __declspec(dllexport)
@@ -43,6 +43,7 @@
 #else
     #define ENKITS_API
 #endif
+#endif
 
 // Define ENKI_CUSTOM_ALLOC_FILE_AND_LINE (at project level) to get file and line report in custom allocators,
 // this is default in Debug - to turn off define ENKI_CUSTOM_ALLOC_NO_FILE_AND_LINE
@@ -52,11 +53,13 @@
 #endif
 #endif
 
-
+#ifndef ENKI_ASSERT
+#include <assert.h>
+#define ENKI_ASSERT(x) assert(x)
+#endif
 
 namespace enki
 {
-
     struct TaskSetPartition
     {
         uint32_t start;
@@ -66,13 +69,15 @@ namespace enki
     class  TaskScheduler;
     class  TaskPipe;
     class  PinnedTaskList;
+    class  Dependency;
     struct ThreadArgs;
     struct ThreadDataStore;
     struct SubTaskSet;
     struct semaphoreid_t;
 
-    uint32_t GetNumHardwareThreads();
+    static constexpr uint32_t NO_THREAD_NUM = 0xFFFFFFFF;
 
+    ENKITS_API uint32_t GetNumHardwareThreads();
 
     enum TaskPriority
     {
@@ -85,7 +90,7 @@ namespace enki
 #endif
 #if ( ENKITS_TASK_PRIORITIES_NUM > 4 )
         TASK_PRIORITY_MED_LO,
-#endif 
+#endif
 #if ( ENKITS_TASK_PRIORITIES_NUM > 1 )
         TASK_PRIORITY_LOW,
 #endif
@@ -93,22 +98,41 @@ namespace enki
     };
 
     // ICompletable is a base class used to check for completion.
-    // Do not use this class directly, instead derive from ITaskSet or IPinnedTask.
+    // Can be used with dependencies to wait for their completion.
+    // Derive from ITaskSet or IPinnedTask for running parallel tasks.
     class ICompletable
     {
     public:
-        ICompletable() : m_Priority(TASK_PRIORITY_HIGH), m_RunningCount(0), m_WaitingForTaskCount(0) {}
-        bool                   GetIsComplete() const {
+        bool    GetIsComplete() const {
             return 0 == m_RunningCount.load( std::memory_order_acquire );
         }
 
-        virtual                ~ICompletable() {}
+        virtual ~ICompletable();
 
-        TaskPriority            m_Priority;
+        // Dependency helpers, see Dependencies.cpp
+        void SetDependency( Dependency& dependency_, const ICompletable* pDependencyTask_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D& dependencyArray_ , const T(&taskArray_)[SIZE] );
+        template<typename D, typename T>           void SetDependenciesArr( D& dependencyArray_, std::initializer_list<T*> taskpList_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D(&dependencyArray_)[SIZE], const T(&taskArray_)[SIZE] );
+        template<typename D, typename T, int SIZE> void SetDependenciesArr( D(&dependencyArray_)[SIZE], std::initializer_list<T*> taskpList_ );
+        template<typename D, typename T, int SIZE> void SetDependenciesVec( D& dependencyVec_, const T(&taskArray_)[SIZE] );
+        template<typename D, typename T>           void SetDependenciesVec( D& dependencyVec_, std::initializer_list<T*> taskpList_ );
+
+        TaskPriority                   m_Priority            = TASK_PRIORITY_HIGH;
+    protected:
+        // Deriving from an ICompletable and overriding OnDependenciesComplete is advanced use.
+        // If you do override OnDependenciesComplete() call:
+        // ICompletable::OnDependenciesComplete( pTaskScheduler_, threadNum_ );
+        // in your implementation.
+        virtual void                   OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ );
     private:
         friend class                   TaskScheduler;
-        std::atomic<int32_t>           m_RunningCount;
-        mutable std::atomic<int32_t>   m_WaitingForTaskCount;
+        friend class                   Dependency;
+        std::atomic<int32_t>           m_RunningCount               = {0};
+        std::atomic<int32_t>           m_DependenciesCompletedCount = {0};
+        int32_t                        m_DependenciesCount          = 0;
+        mutable std::atomic<int32_t>   m_WaitingForTaskCount        = {0};
+        mutable Dependency*            m_pDependents                = NULL;
     };
 
     // Subclass ITaskSet to create tasks.
@@ -116,16 +140,9 @@ namespace enki
     class ITaskSet : public ICompletable
     {
     public:
-        ITaskSet()
-            : m_SetSize(1)
-            , m_MinRange(1)
-            , m_RangeToRun(1)
-        {}
-
+        ITaskSet() = default;
         ITaskSet( uint32_t setSize_ )
             : m_SetSize( setSize_ )
-            , m_MinRange(1)
-            , m_RangeToRun(1)
         {}
 
         ITaskSet( uint32_t setSize_, uint32_t minRange_ )
@@ -138,62 +155,91 @@ namespace enki
         // range_ where range.start >= 0; range.start < range.end; and range.end < m_SetSize;
         // The range values should be mapped so that linearly processing them in order is cache friendly
         // i.e. neighbouring values should be close together.
-        // threadnum should not be used for changing processing of data, it's intended purpose
+        // threadnum_ should not be used for changing processing of data, its intended purpose
         // is to allow per-thread data buckets for output.
         virtual void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  ) = 0;
 
         // Set Size - usually the number of data items to be processed, see ExecuteRange. Defaults to 1
-        uint32_t     m_SetSize;
+        uint32_t     m_SetSize  = 1;
 
-        // Min Range - Minimum size of of TaskSetPartition range when splitting a task set into partitions.
+        // Min Range - Minimum size of TaskSetPartition range when splitting a task set into partitions.
         // Designed for reducing scheduling overhead by preventing set being
-        // divided up too small. Ranges passed to ExecuteRange will *not* be a mulitple of this,
+        // divided up too small. Ranges passed to ExecuteRange will *not* be a multiple of this,
         // only attempts to deliver range sizes larger than this most of the time.
         // This should be set to a value which results in computation effort of at least 10k
         // clock cycles to minimize task scheduler overhead.
         // NOTE: The last partition will be smaller than m_MinRange if m_SetSize is not a multiple
         // of m_MinRange.
         // Also known as grain size in literature.
-        uint32_t     m_MinRange;
+        uint32_t     m_MinRange  = 1;
 
     private:
         friend class TaskScheduler;
-        uint32_t     m_RangeToRun;
+        void         OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ ) final;
+        uint32_t     m_RangeToRun = 1;
     };
 
     // Subclass IPinnedTask to create tasks which can be run on a given thread only.
     class IPinnedTask : public ICompletable
     {
     public:
-        IPinnedTask()                      : threadNum(0), pNext(NULL) {}  // default is to run a task on main thread
-        IPinnedTask( uint32_t threadNum_ ) : threadNum(threadNum_), pNext(NULL) {}  // default is to run a task on main thread
+        IPinnedTask() = default;
+        IPinnedTask( uint32_t threadNum_ ) : threadNum(threadNum_) {}  // default is to run a task on main thread
 
+        // IPinnedTask needs to be non-abstract for intrusive list functionality.
+        // Should never be called as is, should be overridden.
+        virtual void Execute() { ENKI_ASSERT(false); }
 
-        // IPinnedTask needs to be non abstract for intrusive list functionality.
-        // Should never be called as should be overridden.
-        virtual void Execute() { assert(false); }
-
-
-        uint32_t                  threadNum; // thread to run this pinned task on
-        std::atomic<IPinnedTask*> pNext;        // Do not use. For intrusive list only.
+        uint32_t                  threadNum = 0; // thread to run this pinned task on
+        std::atomic<IPinnedTask*> pNext = {NULL};
+    private:
+        void         OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ ) final;
     };
 
-    // A utility task set for creating tasks based on std::func.
+    // TaskSet - a utility task set for creating tasks based on std::function.
     typedef std::function<void (TaskSetPartition range, uint32_t threadnum  )> TaskSetFunction;
     class TaskSet : public ITaskSet
     {
     public:
         TaskSet() = default;
-        TaskSet( TaskSetFunction func_ ) : m_Function( func_ ) {}
-        TaskSet( uint32_t setSize_, TaskSetFunction func_ ) : ITaskSet( setSize_ ), m_Function( func_ ) {}
+        TaskSet( TaskSetFunction func_ ) : m_Function( std::move(func_) ) {}
+        TaskSet( uint32_t setSize_, TaskSetFunction func_ ) : ITaskSet( setSize_ ), m_Function( std::move(func_) ) {}
 
-
-        virtual void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  )
-        {
-            m_Function( range_, threadnum_ );
-        }
-
+        void ExecuteRange( TaskSetPartition range_, uint32_t threadnum_  ) override { m_Function( range_, threadnum_ ); }
         TaskSetFunction m_Function;
+    };
+
+    // LambdaPinnedTask - a utility pinned task for creating tasks based on std::func.
+    typedef std::function<void ()> PinnedTaskFunction;
+    class LambdaPinnedTask : public IPinnedTask
+    {
+    public:
+        LambdaPinnedTask() = default;
+        LambdaPinnedTask( PinnedTaskFunction func_ ) : m_Function( std::move(func_) ) {}
+        LambdaPinnedTask( uint32_t threadNum_, PinnedTaskFunction func_ ) : IPinnedTask( threadNum_ ), m_Function( std::move(func_) ) {}
+
+        void Execute() override { m_Function(); }
+        PinnedTaskFunction m_Function;
+    };
+
+    class Dependency
+    {
+    public:
+                        Dependency() = default;
+                        Dependency( const Dependency& ) = delete;
+        ENKITS_API      Dependency( Dependency&& ) noexcept;
+        ENKITS_API      Dependency(    const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ );
+        ENKITS_API      ~Dependency();
+
+        ENKITS_API void SetDependency( const ICompletable* pDependencyTask_, ICompletable* pTaskToRunOnCompletion_ );
+        ENKITS_API void ClearDependency();
+              ICompletable* GetTaskToRunOnCompletion() { return pTaskToRunOnCompletion; }
+        const ICompletable* GetDependencyTask()        { return pDependencyTask; }
+    private:
+        friend class TaskScheduler; friend class ICompletable;
+        ICompletable*       pTaskToRunOnCompletion = NULL;
+        const ICompletable* pDependencyTask        = NULL;
+        Dependency*         pNext                  = NULL;
     };
 
     // TaskScheduler implements several callbacks intended for profilers
@@ -233,7 +279,7 @@ namespace enki
         // See TaskScheduler::RegisterExternalTaskThread() for usage.
         // Defaults to 0. The thread used to initialize the TaskScheduler can also use the TaskScheduler API.
         // Thus there are (numTaskThreadsToCreate + numExternalTaskThreads + 1) able to use the API, with this
-        // defaulting to the number of harware threads available to the system.
+        // defaulting to the number of hardware threads available to the system.
         uint32_t          numExternalTaskThreads = 0;
 
         ProfilerCallbacks profilerCallbacks = {};
@@ -267,6 +313,18 @@ namespace enki
         // Get config. Can be called before Initialize to get the defaults.
         ENKITS_API TaskSchedulerConfig GetConfig() const;
 
+        // while( !GetIsShutdownRequested() ) {} can be used in tasks which loop, to check if enkiTS has been requested to shutdown.
+        // If GetIsShutdownRequested() returns true should then exit. Not required for finite tasks
+        // Safe to use with WaitforAllAndShutdown() and ShutdownNow() where this will be set
+        // Not safe to use with WaitforAll(), use GetIsWaitforAllCalled() instead.
+        inline     bool            GetIsShutdownRequested() const { return m_bShutdownRequested.load( std::memory_order_acquire ); }
+
+        // while( !GetIsWaitforAllCalled() ) {} can be used in tasks which loop, to check if WaitforAll() has been called.
+        // If GetIsWaitforAllCalled() returns false should then exit. Not required for finite tasks
+        // This is intended to be used with code which calls WaitforAll().
+        // This is also set when the task manager is shutting down, so no need to have an additional check for GetIsShutdownRequested()
+        inline     bool            GetIsWaitforAllCalled() const { return m_bWaitforAllCalled.load( std::memory_order_acquire ); }
+
         // Adds the TaskSet to pipe and returns if the pipe is not full.
         // If the pipe is full, pTaskSet is run.
         // should only be called from main thread, or within a task
@@ -277,19 +335,22 @@ namespace enki
         ENKITS_API void            AddPinnedTask( IPinnedTask* pTask_ );
 
         // This function will run any IPinnedTask* for current thread, but not run other
-        // Main thread should call this or use a wait to ensure it's tasks are run.
+        // Main thread should call this or use a wait to ensure its tasks are run.
         ENKITS_API void            RunPinnedTasks();
 
         // Runs the TaskSets in pipe until true == pTaskSet->GetIsComplete();
-        // should only be called from thread which created the taskscheduler , or within a task
-        // if called with 0 it will try to run tasks, and return if none available.
+        // Should only be called from thread which created the task scheduler, or within a task.
+        // If called with 0 it will try to run tasks, and return if none are available.
         // To run only a subset of tasks, set priorityOfLowestToRun_ to a high priority.
         // Default is lowest priority available.
         // Only wait for child tasks of the current task otherwise a deadlock could occur.
+        // WaitforTask will exit if ShutdownNow() is called even if pCompletable_ is not complete.
         ENKITS_API void            WaitforTask( const ICompletable* pCompletable_, enki::TaskPriority priorityOfLowestToRun_ = TaskPriority(TASK_PRIORITY_NUM - 1) );
 
         // Waits for all task sets to complete - not guaranteed to work unless we know we
         // are in a situation where tasks aren't being continuously added.
+        // If you are running tasks which loop, make sure to check GetIsWaitforAllCalled() and exit
+        // WaitforAll will exit if ShutdownNow() is called even if there are still tasks to run or currently running
         ENKITS_API void            WaitforAll();
 
         // Waits for all task sets to complete and shutdown threads - not guaranteed to work unless we know we
@@ -297,26 +358,46 @@ namespace enki
         // This function can be safely called even if TaskScheduler::Initialize() has not been called.
         ENKITS_API void            WaitforAllAndShutdown();
 
+        // Shutdown threads without waiting for all tasks to complete.
+        // Intended to be used to exit an application quickly.
+        // This function can be safely called even if TaskScheduler::Initialize() has not been called.
+        // This function will still wait for any running tasks to exit before the task threads exit.
+        // ShutdownNow will cause tasks which have been added to the scheduler but not completed
+        // to be in an undefined state in which should not be re-launched.
+        ENKITS_API void            ShutdownNow();
+
+        // Waits for the current thread to receive a PinnedTask.
+        // Will not run any tasks - use with RunPinnedTasks().
+        // Can be used with both ExternalTaskThreads or with an enkiTS tasking thread to create
+        // a thread which only runs pinned tasks. If enkiTS threads are used can create
+        // extra enkiTS task threads to handle non-blocking computation via normal tasks.
+        ENKITS_API void            WaitForNewPinnedTasks();
+
         // Returns the number of threads created for running tasks + number of external threads
         // plus 1 to account for the thread used to initialize the task scheduler.
         // Equivalent to config values: numTaskThreadsToCreate + numExternalTaskThreads + 1.
         // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
         ENKITS_API uint32_t        GetNumTaskThreads() const;
 
-        // Returns the current task threadNum
+        // Returns the current task threadNum.
         // Will return 0 for thread which initialized the task scheduler,
-        // and all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
-        // and < GetNumTaskThreads() for all threads.
-        // It is guaranteed that GetThreadNum() < GetNumTaskThreads()
+        // and NO_THREAD_NUM for all other non-enkiTS threads which have not been registered ( see RegisterExternalTaskThread() ),
+        // and < GetNumTaskThreads() for all registered and internal enkiTS threads.
+        // It is guaranteed that GetThreadNum() < GetNumTaskThreads() unless it is NO_THREAD_NUM
         ENKITS_API uint32_t        GetThreadNum() const;
 
-         // Call on a thread to register the thread to use the TaskScheduling API.
+        // Call on a thread to register the thread to use the TaskScheduling API.
         // This is implicitly done for the thread which initializes the TaskScheduler
         // Intended for developers who have threads who need to call the TaskScheduler API
-        // Returns true if successfull, false if not.
+        // Returns true if successful, false if not.
         // Can only have numExternalTaskThreads registered at any one time, which must be set
         // at initialization time.
         ENKITS_API bool            RegisterExternalTaskThread();
+
+        // As RegisterExternalTaskThread() but explicitly requests a given thread number.
+        // threadNumToRegister_ must be  >= GetNumFirstExternalTaskThread()
+        // and < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads ).
+        ENKITS_API bool            RegisterExternalTaskThread( uint32_t threadNumToRegister_ );
 
         // Call on a thread on which RegisterExternalTaskThread has been called to deregister that thread.
         ENKITS_API void            DeRegisterExternalTaskThread();
@@ -324,18 +405,32 @@ namespace enki
         // Get the number of registered external task threads.
         ENKITS_API uint32_t        GetNumRegisteredExternalTaskThreads();
 
+        // Get the thread number of the first external task thread. This thread
+        // is not guaranteed to be registered, but threads are registered in order
+        // from GetNumFirstExternalTaskThread() up to ( GetNumFirstExternalTaskThread() + numExternalTaskThreads )
+        // Note that if numExternalTaskThreads == 0 a for loop using this will be valid:
+        // for( uint32_t externalThreadNum = GetNumFirstExternalTaskThread();
+        //      externalThreadNum < ( GetNumFirstExternalTaskThread() + numExternalTaskThreads
+        //      ++externalThreadNum ) { // do something with externalThreadNum }
+        inline static constexpr uint32_t  GetNumFirstExternalTaskThread() { return 1; }
 
         // ------------- Start DEPRECATED Functions -------------
-        // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask
+        // DEPRECATED: use GetIsShutdownRequested() instead of GetIsRunning() in external code
+        // while( GetIsRunning() ) {} can be used in tasks which loop, to check if enkiTS has been shutdown.
+        // If GetIsRunning() returns false should then exit. Not required for finite tasks.
+        inline     bool            GetIsRunning() const { return m_bRunning.load( std::memory_order_acquire ); }
+
+        // DEPRECATED - WaitforTaskSet, deprecated interface use WaitforTask.
         inline void                WaitforTaskSet( const ICompletable* pCompletable_ ) { WaitforTask( pCompletable_ ); }
 
-        // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead
+        // DEPRECATED - GetProfilerCallbacks.  Use TaskSchedulerConfig instead.
         // Returns the ProfilerCallbacks structure so that it can be modified to
         // set the callbacks. Should be set prior to initialization.
         inline ProfilerCallbacks* GetProfilerCallbacks() { return &m_Config.profilerCallbacks; }
         // -------------  End DEPRECATED Functions  -------------
 
     private:
+        friend class ICompletable; friend class ITaskSet; friend class IPinnedTask;
         static void TaskingThreadFunction( const ThreadArgs& args_ );
         bool        HaveTasks( uint32_t threadNum_ );
         void        WaitForNewTasks( uint32_t threadNum_ );
@@ -348,12 +443,18 @@ namespace enki
         void        SplitAndAddTask( uint32_t threadNum_, SubTaskSet subTask_, uint32_t rangeToSplit_ );
         void        WakeThreadsForNewTasks();
         void        WakeThreadsForTaskCompletion();
-        bool        WakeSuspendedThreadsWithPinnedTasks();
+        bool        WakeSuspendedThreadsWithPinnedTasks( uint32_t threadNum_ );
+        void        InitDependencies( ICompletable* pCompletable_  );
+        ENKITS_API void TaskComplete( ICompletable* pTask_, bool bWakeThreads_, uint32_t threadNum_ );
+        ENKITS_API void AddTaskSetToPipeInt( ITaskSet* pTaskSet_, uint32_t threadNum_ );
+        ENKITS_API void AddPinnedTaskInt( IPinnedTask* pTask_ );
 
         template< typename T > T*   NewArray( size_t num_, const char* file_, int line_  );
         template< typename T > void DeleteArray( T* p_, size_t num_, const char* file_, int line_ );
         template<class T, class... Args> T* New( const char* file_, int line_,  Args&&... args_ );
         template< typename T > void Delete( T* p_, const char* file_, int line_ );
+        template< typename T > T*   Alloc( const char* file_, int line_ );
+        template< typename T > void Free( T* p_, const char* file_, int line_ );
         semaphoreid_t* SemaphoreNew();
         void SemaphoreDelete( semaphoreid_t* pSemaphore_ );
 
@@ -363,7 +464,9 @@ namespace enki
         uint32_t               m_NumThreads;
         ThreadDataStore*       m_pThreadDataStore;
         std::thread*           m_pThreads;
-        std::atomic<int32_t>   m_bRunning;
+        std::atomic<bool>      m_bRunning;
+        std::atomic<bool>      m_bShutdownRequested;
+        std::atomic<bool>      m_bWaitforAllCalled;
         std::atomic<int32_t>   m_NumInternalTaskThreadsRunning;
         std::atomic<int32_t>   m_NumThreadsWaitingForNewTasks;
         std::atomic<int32_t>   m_NumThreadsWaitingForTaskCompletion;
@@ -382,8 +485,91 @@ namespace enki
         void SetCustomAllocator( CustomAllocator customAllocator_ ); // for C interface
     };
 
-    inline uint32_t GetNumHardwareThreads()
+    inline void ICompletable::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
     {
-        return std::thread::hardware_concurrency();
+        m_RunningCount.fetch_sub( 1, std::memory_order_acq_rel );
+        pTaskScheduler_->TaskComplete( this, true, threadNum_ );
+    }
+
+    inline void ITaskSet::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
+    {
+        pTaskScheduler_->AddTaskSetToPipeInt( this, threadNum_ );
+    }
+
+    inline void IPinnedTask::OnDependenciesComplete( TaskScheduler* pTaskScheduler_, uint32_t threadNum_ )
+    {
+        (void)threadNum_;
+        pTaskScheduler_->AddPinnedTaskInt( this );
+    }
+
+    inline ICompletable::~ICompletable()
+    {
+        ENKI_ASSERT( GetIsComplete() ); // this task is still waiting to run
+        Dependency* pDependency = m_pDependents;
+        while( pDependency )
+        {
+            Dependency* pNext = pDependency->pNext;
+            pDependency->pDependencyTask = NULL;
+            pDependency->pNext = NULL;
+            pDependency = pNext;
+        }
+    }
+
+    inline void ICompletable::SetDependency( Dependency& dependency_, const ICompletable* pDependencyTask_ )
+    {
+        ENKI_ASSERT( pDependencyTask_ != this );
+        dependency_.SetDependency( pDependencyTask_, this );
+    }
+
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D& dependencyArray_ , const T(&taskArray_)[SIZE] ) {
+        static_assert( std::tuple_size<D>::value >= SIZE, "Size of dependency array too small" );
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyArray_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+    template<typename D, typename T>
+    void ICompletable::SetDependenciesArr( D& dependencyArray_, std::initializer_list<T*> taskpList_ ) {
+        ENKI_ASSERT( std::tuple_size<D>::value >= taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyArray_[i++].SetDependency( pTask, this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D(&dependencyArray_)[SIZE], const T(&taskArray_)[SIZE] ) {
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyArray_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesArr( D(&dependencyArray_)[SIZE], std::initializer_list<T*> taskpList_ ) {
+        ENKI_ASSERT( SIZE >= taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyArray_[i++].SetDependency( pTask, this );
+        }
+    }
+    template<typename D, typename T, int SIZE>
+    void ICompletable::SetDependenciesVec( D& dependencyVec_, const T(&taskArray_)[SIZE] ) {
+        dependencyVec_.resize( SIZE );
+        for( int i = 0; i < SIZE; ++i )
+        {
+            dependencyVec_[i].SetDependency( &taskArray_[i], this );
+        }
+    }
+
+    template<typename D, typename T>
+    void ICompletable::SetDependenciesVec( D& dependencyVec_, std::initializer_list<T*> taskpList_ ) {
+        dependencyVec_.resize( taskpList_.size() );
+        int i = 0;
+        for( auto pTask : taskpList_ )
+        {
+            dependencyVec_[i++].SetDependency( pTask, this );
+        }
     }
 }


### PR DESCRIPTION
* Add a workaround for no `ftello64` on FreeBSD, reusing the one for Darwin.

After the first change I was able to build ClangBuildAnalyzer but tests had many coredumps and memory safety errors discovered by valgrind and ASAN. Updating enkiTS seems to fix the issue and build still works for me on Linux.