### PR TITLE
Remove warnings

### DIFF
--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -15,6 +15,7 @@
 #include "external/simdjson/simdjson.h"
 #include "external/xxHash/xxhash.h"
 #include <assert.h>
+#include <cinttypes>
 #include <iterator>
 #include <mutex>
 
@@ -57,7 +58,7 @@ static void DebugPrintEvents(const BuildEvents& events, const BuildNames& names)
     {
         const BuildEvent& event = events[EventIndex(int(i))];
         const std::string_view namesSubstr = names[event.detailIndex].substr(0, 130);
-        printf("%4zi: t=%i t1=%7lld t2=%7lld par=%4i ch=%4zi det=%.*s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), (int)namesSubstr.size(), namesSubstr.data());
+        printf("%4zi: t=%i t1=%7" PRId64 " t2=%7" PRId64 " par=%4i ch=%4zi det=%.*s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), (int)namesSubstr.size(), namesSubstr.data());
     }
 }
 

--- a/src/BuildEvents.cpp
+++ b/src/BuildEvents.cpp
@@ -526,7 +526,7 @@ struct BufferedReader
     size_t bufferSize;
 };
 
-const uint32_t kFileMagic = 'CBA0';
+const uint32_t kFileMagic = 0x43424130; // 'CBA0'
 
 bool SaveBuildEvents(BuildEventsParser* parser, const std::string& fileName)
 {


### PR DESCRIPTION
When compiling the latest `master` on gcc 13.2.0 (Ubuntu 24.04.1) the following warnings were produced, which this PR fixes:

```
/home/rtobar/scm/git/ClangBuildAnalyzer/src/BuildEvents.cpp:528:29: warning: multi-character character constant [-Wmultichar]
  528 | const uint32_t kFileMagic = 'CBA0';
      |                             ^~~~~~
/home/rtobar/scm/git/ClangBuildAnalyzer/src/BuildEvents.cpp: In function ‘void DebugPrintEvents(const BuildEvents&, const BuildNames&)’:
/home/rtobar/scm/git/ClangBuildAnalyzer/src/BuildEvents.cpp:60:35: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘long int’ [-Wformat=]
   60 |         printf("%4zi: t=%i t1=%7lld t2=%7lld par=%4i ch=%4zi det=%.*s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), (int)namesSubstr.size(), namesSubstr.data());
      |                               ~~~~^                                                            ~~~~~~~~
      |                                   |                                                                  |
      |                                   long long int                                                      long int
      |                               %7ld
/home/rtobar/scm/git/ClangBuildAnalyzer/src/BuildEvents.cpp:60:44: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 5 has type ‘long int’ [-Wformat=]
   60 |         printf("%4zi: t=%i t1=%7lld t2=%7lld par=%4i ch=%4zi det=%.*s\n", i, (int) event.type, event.ts, event.ts+event.dur, event.parent.idx, event.children.size(), (int)namesSubstr.size(), namesSubstr.data());
      |                                        ~~~~^                                                             ~~~~~~~~~~~~~~~~~~
      |                                            |                                                                     |
      |                                            long long int                                                         long int
      |                                        %7ld
```