### PR TITLE
src: Fix builds with musl (instead of glibc) on Linux

### DIFF
--- a/src/BuildEvents.h
+++ b/src/BuildEvents.h
@@ -11,7 +11,7 @@
 
 #ifdef _MSC_VER
 #define ftello64 _ftelli64
-#elif defined(__APPLE__) || defined(__FreeBSD__)
+#elif defined(__APPLE__) || defined(__FreeBSD__) || (defined(__linux__) && !defined(__GLIBC__))
 #define ftello64 ftello
 #endif
 


### PR DESCRIPTION
As 'ftello64' is a glibc-only extension, the build fails when using musl. Here,
the plain 'ftello' is sufficient for 64-bit support.

Fixes #103