### PR TITLE
Display origin of template instantiations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,18 +3,12 @@ project(ClangBuildAnalyzer)
 
 include(GNUInstallDirs)
 
-set(SRC
+set(EXTERNAL_SRC
 # C sources
     "src/external/cwalk/cwalk.c"
     "src/external/inih/ini.c"
     "src/external/xxHash/xxhash.c"
 # C++ sources
-    "src/Analysis.cpp"
-    "src/Arena.cpp"
-    "src/BuildEvents.cpp"
-    "src/Colors.cpp"
-    "src/main.cpp"
-    "src/Utils.cpp"
     "src/external/enkiTS/TaskScheduler.cpp"
     "src/external/inih/cpp/INIReader.cpp"
     "src/external/llvm-Demangle/lib/Demangle.cpp"
@@ -23,7 +17,34 @@ set(SRC
     "src/external/llvm-Demangle/lib/MicrosoftDemangleNodes.cpp"
     "src/external/simdjson/simdjson.cpp"
 )
-add_executable(ClangBuildAnalyzer "${SRC}")
+
+set(SRC
+# C++ sources
+    "src/Analysis.cpp"
+    "src/Arena.cpp"
+    "src/BuildEvents.cpp"
+    "src/Colors.cpp"
+    "src/main.cpp"
+    "src/Utils.cpp"
+)
+
+set(DISABLE_WARNINGS_FLAG "")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang|AppleClang|Intel") # Check C++ compiler first
+    set(DISABLE_WARNINGS_FLAG "-w")
+elseif(CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|AppleClang|Intel") # Fallback for C-only
+    set(DISABLE_WARNINGS_FLAG "-w")
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    set(DISABLE_WARNINGS_FLAG "/w") # MSVC uses /w
+elseif(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+    set(DISABLE_WARNINGS_FLAG "/w")
+endif()
+
+set_source_files_properties(${EXTERNAL_SRC}
+    PROPERTIES COMPILE_FLAGS "${DISABLE_WARNINGS_FLAG}"
+)
+
+add_executable(ClangBuildAnalyzer "${EXTERNAL_SRC}" "${SRC}")
 target_compile_features(ClangBuildAnalyzer PRIVATE cxx_std_17)
 
 find_library(LIBRT rt)

--- a/ClangBuildAnalyzer.ini
+++ b/ClangBuildAnalyzer.ini
@@ -6,17 +6,17 @@
 [counts]
 
 # files that took most time to parse
-fileParse = 10
+fileParse = 20
 # files that took most time to generate code for
-fileCodegen = 10
+fileCodegen = 20
 # functions that took most time to generate code for
 function = 30
 # header files that were most expensive to include
-header = 10
+header = 20
 # for each expensive header, this many include paths to it are shown
-headerChain = 5
+headerChain = 10
 # templates that took longest to instantiate
-template = 30
+template = 50
 
 
 # Minimum times (in ms) for things to be recorded into trace
@@ -29,7 +29,7 @@ file = 10
 [misc]
 
 # Maximum length of symbol names printed; longer names will get truncated
-maxNameLength = 70
+maxNameLength = 512
 
 # Only print "root" headers in expensive header report, i.e.
 # only headers that are directly included by at least one source file

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -1,7 +1,6 @@
 // Clang Build Analyzer https://github.com/aras-p/ClangBuildAnalyzer
 // SPDX-License-Identifier: Unlicense
 
-#include <iostream>
 #ifdef _MSC_VER
 struct IUnknown; // workaround for old Win SDK header failures when using /permissive-
 #endif
@@ -117,6 +116,8 @@ struct Analysis
     void EmitCollapsedInfo(
         const ska::bytell_hash_map<std::string_view, InstantiateEntry> &collapsed,
         const char *header_string);
+
+    void PrintSortedTemplateCounts(const InstantiateEntry& e);
 
     // key is (name,objfile), value is milliseconds
     typedef std::pair<DetailIndex, DetailIndex> IndexPair;
@@ -285,6 +286,33 @@ std::string_view Analysis::GetCollapsedName(DetailIndex detail)
     return name;
 }
 
+void Analysis::PrintSortedTemplateCounts(const InstantiateEntry& e)
+{
+    std::vector<std::pair<int, int>> templateCounts;
+    templateCounts.reserve(e.templateCount.size());
+
+    for (const auto& t : e.templateCount)
+    {
+        if (t.second < 3) // TODO: make customizable
+            continue;
+
+        templateCounts.emplace_back(t.first, t.second);
+    }
+
+    std::sort(templateCounts.begin(), templateCounts.end(), [](const auto& a, const auto& b)
+    {
+        if (a.second != b.second)
+            return a.second > b.second;
+
+        return a.first < b.first;
+    });
+
+    for (const auto& t : e.templateCount)
+    {
+        fprintf(out, "  %s%6i%s time(s): %s\n", col::kBold, t.second, col::kReset, GetBuildName(DetailIndex{t.first}).data());
+    }
+}
+
 void Analysis::EmitCollapsedInfo(
     const ska::bytell_hash_map<std::string_view, InstantiateEntry> &collapsed,
     const char *header_string)
@@ -309,10 +337,7 @@ void Analysis::EmitCollapsedInfo(
         int avg = int(ms / elt.second.count);
         fprintf(out, "%s%6i%s ms: %s (%i times, avg %i ms)\n", col::kBold, ms, col::kReset, dname.c_str(), elt.second.count, avg);
 
-        for (const auto& t : elt.second.templateCount)
-        {
-            fprintf(out, "  %s%6i%s time(s): %s\n", col::kBold, t.second, col::kReset, GetBuildName(DetailIndex{t.first}).data());
-        }
+        PrintSortedTemplateCounts(elt.second);
     }
     fprintf(out, "\n");
 }
@@ -452,10 +477,7 @@ void Analysis::EndAnalysis()
             int avg = int(ms / std::max(e.second.count,1));
             fprintf(out, "%s%6i%s ms: %s (%i times, avg %i ms)\n", col::kBold, ms, col::kReset, dname.c_str(), e.second.count, avg);
 
-            for (const auto& t : e.second.templateCount)
-            {
-                fprintf(out, "  %s%6i%s time(s): %s\n", col::kBold, t.second, col::kReset, GetBuildName(DetailIndex{t.first}).data());
-            }
+            PrintSortedTemplateCounts(e.second);
         }
         fprintf(out, "\n");
 

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -111,7 +111,7 @@ struct Analysis
 
     ska::bytell_hash_map<DetailIndex, std::string_view> collapsedNames;
     std::string_view GetCollapsedName(DetailIndex idx);
-    void EmitCollapsedTemplates();5
+    void EmitCollapsedTemplates();
     void EmitCollapsedTemplateOpt();
     void EmitCollapsedInfo(
         const ska::bytell_hash_map<std::string_view, InstantiateEntry> &collapsed,

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -21,16 +21,16 @@ struct IUnknown; // workaround for old Win SDK header failures when using /permi
 
 struct Config
 {
-    int fileParseCount = 10;
-    int fileCodegenCount = 10;
-    int templateCount = 30;
+    int fileParseCount = 20;
+    int fileCodegenCount = 20;
+    int templateCount = 50;
     int functionCount = 30;
-    int headerCount = 10;
-    int headerChainCount = 5;
+    int headerCount = 20;
+    int headerChainCount = 10;
 
     int minFileTime = 10;
 
-    int maxName = 70;
+    int maxName = 512;
 
     bool onlyRootHeaders = true;
 };
@@ -111,7 +111,7 @@ struct Analysis
 
     ska::bytell_hash_map<DetailIndex, std::string_view> collapsedNames;
     std::string_view GetCollapsedName(DetailIndex idx);
-    void EmitCollapsedTemplates();
+    void EmitCollapsedTemplates();5
     void EmitCollapsedTemplateOpt();
     void EmitCollapsedInfo(
         const ska::bytell_hash_map<std::string_view, InstantiateEntry> &collapsed,

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -307,7 +307,7 @@ void Analysis::PrintSortedTemplateCounts(const InstantiateEntry& e)
         return a.first < b.first;
     });
 
-    for (const auto& t : e.templateCount)
+    for (const auto& t : templateCounts)
     {
         fprintf(out, "  %s%6i%s time(s): %s\n", col::kBold, t.second, col::kReset, GetBuildName(DetailIndex{t.first}).data());
     }

--- a/src/BuildEvents.h
+++ b/src/BuildEvents.h
@@ -80,6 +80,7 @@ struct BuildEvent
     int64_t ts = 0;
     int64_t dur = 0;
     DetailIndex detailIndex;
+    DetailIndex filenameDetailIndex;
     EventIndex parent{ -1 };
     char phase = 0;
     std::vector<EventIndex> children;


### PR DESCRIPTION
Addresses #93. Could be improved in the future, but it's already quite useful. Example output:

```
**** Templates that took longest to instantiate:
   602 ms: std::vformat_to<std::__format::_Sink_iter<char>> (5 times, avg 120 ms)
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/StackTrace.cpp.obj
       1 time(s): .//_deps/cpptrace-build/CMakeFiles/cpptrace-lib.dir/Unity/unity_0_cxx.cxx.obj
       1 time(s): .//test/CMakeFiles/test-sfml-system.dir/System/Time.test.cpp.obj
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/Clock.cpp.obj
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/ThreadPool.cpp.obj
   601 ms: std::__format::__do_vformat_to<std::__format::_Sink_iter<char>, char... (5 times, avg 120 ms)
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/StackTrace.cpp.obj
       1 time(s): .//_deps/cpptrace-build/CMakeFiles/cpptrace-lib.dir/Unity/unity_0_cxx.cxx.obj
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/ThreadPool.cpp.obj
       1 time(s): .//test/CMakeFiles/test-sfml-system.dir/System/Time.test.cpp.obj
       1 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/Clock.cpp.obj
```

```
**** Template sets that took longest to instantiate:
   717 ms: std::formatter<$>::format<$> (117 times, avg 6 ms)
      23 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/StackTrace.cpp.obj
      23 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/__/Base/ThreadPool.cpp.obj
      24 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/Clock.cpp.obj
      24 time(s): .//test/CMakeFiles/test-sfml-system.dir/System/Time.test.cpp.obj
      23 time(s): .//_deps/cpptrace-build/CMakeFiles/cpptrace-lib.dir/Unity/unity_0_cxx.cxx.obj
   676 ms: std::common_reference<$> (881 times, avg 0 ms)
       1 time(s): .//test/CMakeFiles/test-sfml-audio.dir/Audio/SoundBuffer.test.cpp.obj
       3 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/FileUtils.cpp.obj
       1 time(s): .//test/CMakeFiles/test-sfml-audio.dir/Audio/InputSoundFile.test.cpp.obj
       6 time(s): .//src/SFML/Network/CMakeFiles/sfml-network.dir/Http.cpp.obj
       7 time(s): .//test/CMakeFiles/test-sfml-network.dir/Network/Packet.test.cpp.obj
       6 time(s): .//test/CMakeFiles/test-sfml-graphics.dir/Graphics/Transform.test.cpp.obj
      17 time(s): .//src/SFML/Window/CMakeFiles/sfml-window.dir/SDLLayer.cpp.obj
      30 time(s): .//src/SFML/System/CMakeFiles/sfml-system.dir/Clock.cpp.obj
```

This PR needs work, but I'd like to get some feedback first on how to proceed. It's mostly a hack at this point.