### PR TITLE
Optionally print full path in header chains

### DIFF
--- a/ClangBuildAnalyzer.ini
+++ b/ClangBuildAnalyzer.ini
@@ -34,3 +34,6 @@ maxNameLength = 70
 # Only print "root" headers in expensive header report, i.e.
 # only headers that are directly included by at least one source file
 onlyRootHeaders = true
+
+# In header include chains, print full file paths instead of just filenames
+headerChainFullPath = false

--- a/src/Analysis.cpp
+++ b/src/Analysis.cpp
@@ -33,6 +33,8 @@ struct Config
     int maxName = 70;
 
     bool onlyRootHeaders = true;
+
+    bool headerChainFullPath = false;
 };
 
 struct pair_hash
@@ -525,7 +527,8 @@ void Analysis::EndAnalysis()
                 fprintf(out, "  %ix: ", chain.count);
                 for (auto it = chain.files.rbegin(), itEnd = chain.files.rend(); it != itEnd; ++it)
                 {
-                    fprintf(out, "%s ", utils::GetFilename(GetBuildName(*it)).data());
+                    const auto buildName = GetBuildName(*it);
+                    fprintf(out, "%s ", (config.headerChainFullPath ? buildName : utils::GetFilename(buildName)).data());
                 }
                 if (chain.files.empty())
                     fprintf(out, "<direct include>");
@@ -567,17 +570,18 @@ void Analysis::ReadConfig()
 {
     INIReader ini("ClangBuildAnalyzer.ini");
 
-    config.fileParseCount   = (int)ini.GetInteger("counts", "fileParse",    config.fileParseCount);
-    config.fileCodegenCount = (int)ini.GetInteger("counts", "fileCodegen",  config.fileCodegenCount);
-    config.functionCount    = (int)ini.GetInteger("counts", "function",     config.functionCount);
-    config.templateCount    = (int)ini.GetInteger("counts", "template",     config.templateCount);
-    config.headerCount      = (int)ini.GetInteger("counts", "header",       config.headerCount);
-    config.headerChainCount = (int)ini.GetInteger("counts", "headerChain",  config.headerChainCount);
+    config.fileParseCount      = (int)ini.GetInteger("counts", "fileParse",    config.fileParseCount);
+    config.fileCodegenCount    = (int)ini.GetInteger("counts", "fileCodegen",  config.fileCodegenCount);
+    config.functionCount       = (int)ini.GetInteger("counts", "function",     config.functionCount);
+    config.templateCount       = (int)ini.GetInteger("counts", "template",     config.templateCount);
+    config.headerCount         = (int)ini.GetInteger("counts", "header",       config.headerCount);
+    config.headerChainCount    = (int)ini.GetInteger("counts", "headerChain",  config.headerChainCount);
 
-    config.minFileTime      = (int)ini.GetInteger("minTimes", "file",       config.minFileTime);
+    config.minFileTime         = (int)ini.GetInteger("minTimes", "file",       config.minFileTime);
 
-    config.maxName          = (int)ini.GetInteger("misc", "maxNameLength",  config.maxName);
-    config.onlyRootHeaders  =      ini.GetBoolean("misc", "onlyRootHeaders",config.onlyRootHeaders);
+    config.maxName             = (int)ini.GetInteger("misc", "maxNameLength",           config.maxName);
+    config.onlyRootHeaders     =      ini.GetBoolean("misc", "onlyRootHeaders",         config.onlyRootHeaders);
+    config.headerChainFullPath =      ini.GetBoolean("misc", "headerChainFullPath", config.headerChainFullPath);
 }
 
 


### PR DESCRIPTION
Larger projects may have multiple headers with the same filename but in different directories. Add option to better disambiguate them.

Adds a new config option `headerChainFullPath` to switch between printing just the filename or the full file path.

The default is false, keeping current behavior, i.e., filenames only